### PR TITLE
enable env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN set -x && \
     apt-get clean -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* && \
 #
+# Enable env module:
+    sed -i '/load_module/ a\    load_module modules/ngx_http_env_module.so;' /etc/nginx/nginx.conf && \
 # Do some other stuff
     echo "alias dir=\"ls -alsv\"" >> /root/.bashrc && \
     echo "alias nano=\"nano -l\"" >> /root/.bashrc && \


### PR DESCRIPTION
In this modified Dockerfile, the sed command adds a new line to the nginx.conf file that loads the env module. The modules directory containing the ngx_http_env_module.so file is present in the default Nginx installation directory, so we don't need to install any additional packages.