### PR TITLE
Enable env module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN set -x && \
         ${KEPT_PACKAGES[@]} \
         ${TEMP_PACKAGES[@]} && \
 #
+# Enable env module:
+    sed -i '/load_module/ a\    load_module modules/ngx_http_env_module.so;' /etc/nginx/nginx.conf && \
+    
 # Clean up:
     apt-get remove -y ${TEMP_PACKAGES[@]} && \
     apt-get autoremove -o APT::Autoremove::RecommendsImportant=0 -o APT::Autoremove::SuggestsImportant=0 -y && \


### PR DESCRIPTION
In this modified Dockerfile, the sed command adds a new line to the nginx.conf file that loads the env module. The modules directory containing the ngx_http_env_module.so file is present in the default Nginx installation directory, so we don't need to install any additional packages.