### PR TITLE
chore(flake/precommit): `3076ff29` -> `50bd447e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783710964,
-        "narHash": "sha256-Wlkb4KVuE16CSQ4XPtc4KGwf5KSp7LS7TWCXDicxtns=",
+        "lastModified": 1784275620,
+        "narHash": "sha256-vk/LLBBfr2c25A0IpvSqGbzqDtybWUnxO4YsiSCeWeg=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "3076ff29e23e52d8c3cd4c18d8ec086ed6ba8380",
+        "rev": "50bd447e1d3206ea63716ef6c77ac0deba9f0276",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783663825,
-        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
+        "lastModified": 1784265529,
+        "narHash": "sha256-ohQQiPOngux8ofsrSlloHCMDhRMvocXqJiG8uH45Q5k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
+        "rev": "068175006cfb69d5b541a140ed93e361488c9e53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`50bd447e`](https://github.com/fredsystems/pre-commit-checks/commit/50bd447e1d3206ea63716ef6c77ac0deba9f0276) | `` chore(flake/nixpkgs): e7a3ca80 -> 753cc8a3 ``      |
| [`1f9ef53d`](https://github.com/fredsystems/pre-commit-checks/commit/1f9ef53dcdced2019d6b8ccca22a3f9bb455b819) | `` chore(flake/rust-overlay): a286e5b9 -> 06817500 `` |
| [`7ffbe4d2`](https://github.com/fredsystems/pre-commit-checks/commit/7ffbe4d244ef810e871ff616988753131c9595e8) | `` updates ``                                         |
| [`538e1735`](https://github.com/fredsystems/pre-commit-checks/commit/538e1735c9dc44bb8fc3bc2918a3a5618896a60d) | `` updates ``                                         |
| [`53d43fa0`](https://github.com/fredsystems/pre-commit-checks/commit/53d43fa05b4de2c1041d41a21d58efae2b674c59) | `` chore(flake/nixpkgs): 0bb7ec54 -> e7a3ca80 ``      |
| [`fc8d9b93`](https://github.com/fredsystems/pre-commit-checks/commit/fc8d9b9382519b7f1c256da05eebe82aa7aedfaf) | `` chore(flake/rust-overlay): 072adf9b -> a286e5b9 `` |