### PR TITLE
chore(flake/precommit): `42c10474` -> `58a5f530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786691678,
-        "narHash": "sha256-As8gQAwfN9UFfI0w62bPz60PF2GBa6QYL+MoP7PhWro=",
+        "lastModified": 1787294166,
+        "narHash": "sha256-MSchJhtWP+KQMRUlVC1AuPQItpdn3wtFoeuVdLhdbvk=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "42c10474772f46184668827c86ed97fc7fbd3fb3",
+        "rev": "58a5f5309274af48b6611cafd506383a227d7d61",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1786680812,
-        "narHash": "sha256-5lDFwethgqSULdupYl3Eu5n80jfcbb85gSJX/jb58GQ=",
+        "lastModified": 1787281715,
+        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f1dcc7e4ea4fdb6d8f276face22f353832b161e3",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`58a5f530`](https://github.com/fredsystems/pre-commit-checks/commit/58a5f5309274af48b6611cafd506383a227d7d61) | `` chore(flake/rust-overlay): c84e121a -> 89abdfd6 `` |
| [`40049176`](https://github.com/fredsystems/pre-commit-checks/commit/40049176bd78e79a84322502e11770db8e042e1f) | `` chore(flake/nixpkgs): 0e251e24 -> ffb3c9b7 ``      |
| [`724249bf`](https://github.com/fredsystems/pre-commit-checks/commit/724249bfc4773b7a6640ec1fe78d324dd7ca965c) | `` chore(flake/rust-overlay): f1dcc7e4 -> c84e121a `` |