### PR TITLE
chore(flake/nixpkgs): `83199d0d` -> `c043004d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`06e4e90b`](https://github.com/NixOS/nixpkgs/commit/06e4e90bca182b495430d341232e6d55df177ca6) | `` oklch-color-picker: add desktop entry ``                                                      |
| [`84341778`](https://github.com/NixOS/nixpkgs/commit/8434177859fdec026779700a17f8f5bae376f781) | `` gradle: add riscv64-linux support ``                                                          |
| [`8af16704`](https://github.com/NixOS/nixpkgs/commit/8af167046f16d547c547fbff72269996240f1b5c) | `` gradle-native-platform: init at 0.22 ``                                                       |
| [`ad57cccd`](https://github.com/NixOS/nixpkgs/commit/ad57cccd3f4bd657406c1aba35d37492b651bc53) | `` python3Packages.tahoma-api: drop ``                                                           |
| [`bc6d96eb`](https://github.com/NixOS/nixpkgs/commit/bc6d96ebe717a3974e1884ada3f09f9bd4c9f249) | `` maintainers: drop thepuzzlemaker ``                                                           |
| [`e7dcb0a1`](https://github.com/NixOS/nixpkgs/commit/e7dcb0a18cf3040f5eb5173c35fc4f4165190221) | `` euphonica: 0.99.6-beta-1 -> 0.99.7-beta-1 ``                                                  |
| [`b24a85fd`](https://github.com/NixOS/nixpkgs/commit/b24a85fd8bceed6da4370dea293b04a03ec8f409) | `` google-chat-linux: 5.39.27-1 -> 5.39.28-1 ``                                                  |
| [`101d59cc`](https://github.com/NixOS/nixpkgs/commit/101d59cc34da4fe6f9d24889857135edff7154da) | `` docker-language-server: enable __structuredAttrs ``                                           |
| [`77095110`](https://github.com/NixOS/nixpkgs/commit/770951109e074251fca52186621ccfd906f82260) | `` gh-stack: 0.1.0 -> 0.1.1 ``                                                                   |
| [`ef3fd0e3`](https://github.com/NixOS/nixpkgs/commit/ef3fd0e3c02b0bed05be025bd5cfe3f443c9f82c) | `` microsoft-edge, msedgedriver: 152.0.4191.62 -> 152.0.4191.66 ``                               |
| [`4ca016a0`](https://github.com/NixOS/nixpkgs/commit/4ca016a0f95b4a59a07d7a52c180ebf902da32be) | `` docker-compose: cleanup ``                                                                    |
| [`ef1cebe5`](https://github.com/NixOS/nixpkgs/commit/ef1cebe5df00564e2ccee57567513de05567098b) | `` quickshell: 0.3.0 -> 0.3.1 ``                                                                 |
| [`e31f716b`](https://github.com/NixOS/nixpkgs/commit/e31f716b92e77e69b6e45d4ef289d2c93f238af9) | `` fastcrw: 0.32.0 -> 0.33.0 ``                                                                  |
| [`85f8e8e9`](https://github.com/NixOS/nixpkgs/commit/85f8e8e901c4462cd157be84b8b5c90aed05ebd9) | `` python3Packages.py-cpuinfo2: init at 10.0.1 ``                                                |
| [`0b9dbfd5`](https://github.com/NixOS/nixpkgs/commit/0b9dbfd5fd88009d9501bb55584a95df3f80266c) | `` python3Packages.torchao: 0.17.0 -> 0.18.0 ``                                                  |
| [`800c08c6`](https://github.com/NixOS/nixpkgs/commit/800c08c6c898a0c32c19ca2dc5a1870dee1c4372) | `` python3Packages.geocoder: patch version ``                                                    |
| [`cd5a96e4`](https://github.com/NixOS/nixpkgs/commit/cd5a96e4c59f3f224d3cc804cbf8c30ad3e25300) | `` python3Packages.iamdata: 0.1.202609041 -> 0.1.202609051 ``                                    |
| [`7ac000ed`](https://github.com/NixOS/nixpkgs/commit/7ac000edc64ab2361969c9fba9f912d8728a8381) | `` h5utils: 1.13.2 -> 1.13.3 ``                                                                  |
| [`e2f5db8a`](https://github.com/NixOS/nixpkgs/commit/e2f5db8a1c2e2979c901ab9d1785b7bb6246d592) | `` komodo: 2.3.2 -> 2.3.3 ``                                                                     |
| [`42c3f76f`](https://github.com/NixOS/nixpkgs/commit/42c3f76f40693fd90a3e8bb214386b93c603d26b) | `` vimPlugins.slang-server-nvim: add slang-server as runtime dependency ``                       |
| [`e2e1d5d2`](https://github.com/NixOS/nixpkgs/commit/e2e1d5d26a7d6f5e639e7721459da25ece304f3c) | `` vimPlugins.slang-server-nvim: 0-unstable-2026-06-22 -> 0-unstable-2026-09-04 ``               |
| [`84b4f331`](https://github.com/NixOS/nixpkgs/commit/84b4f33191f79fb655f8532601184db02d1fc1dd) | `` home-assistant: update component packages ``                                                  |
| [`1554911a`](https://github.com/NixOS/nixpkgs/commit/1554911a91e981e37334532c4b00356a00af63c6) | `` python3Packages.sofar-modbus: init at 0.5.0 ``                                                |
| [`feea9050`](https://github.com/NixOS/nixpkgs/commit/feea905076ea4cee29b36db7d6d803a4d35d8c88) | `` home-assistant: update component packages ``                                                  |
| [`5b86ed43`](https://github.com/NixOS/nixpkgs/commit/5b86ed435b2c93adc8597b9df27876986b10a0ca) | `` python3Packages.python-hotspring: init at 2.1.0 ``                                            |
| [`fdd17aab`](https://github.com/NixOS/nixpkgs/commit/fdd17aab7c72cf04946540ec63d564fec5985361) | `` home-assistant: update component packages ``                                                  |
| [`39cbf926`](https://github.com/NixOS/nixpkgs/commit/39cbf926f613c0d1c51b2db355d728422d5010bf) | `` python3Packages.tonewinner-rs232: init at 1.2.2 ``                                            |
| [`713bd7d0`](https://github.com/NixOS/nixpkgs/commit/713bd7d00c0c8e4e6b5265554f9c0a8e80872f0c) | `` home-assistant: update component packages ``                                                  |
| [`669e9507`](https://github.com/NixOS/nixpkgs/commit/669e9507c1053124017df88f8dba6af522931ab4) | `` python3Packages.pysomfymylink: init at 1.1.0 ``                                               |
| [`760f947c`](https://github.com/NixOS/nixpkgs/commit/760f947c24e3f47da0a4d58d775a41a4949a2daa) | `` pgdog: 0.1.54 -> 0.1.57 ``                                                                    |
| [`691adff5`](https://github.com/NixOS/nixpkgs/commit/691adff5ea1b6d201cb4192818220a2aa517c7af) | `` home-assistant: update component packages ``                                                  |
| [`09e4f30a`](https://github.com/NixOS/nixpkgs/commit/09e4f30a4a10c8e46f07a670889e8353373190aa) | `` python3Packages.pysillaprism: init at 0.2.0 ``                                                |
| [`617e3f93`](https://github.com/NixOS/nixpkgs/commit/617e3f93d695b9c44f0cad8669a8b5f8afe088e7) | `` nixos/radicle-ci-broker: add setting logLevel ``                                              |
| [`5dc30350`](https://github.com/NixOS/nixpkgs/commit/5dc30350569aa8bcef84ad1aff8acd10877c9483) | `` lnav: 0.14.0 -> 0.14.1 ``                                                                     |
| [`9911223d`](https://github.com/NixOS/nixpkgs/commit/9911223d707413d785f052f6a159006206a6fa4c) | `` home-assistant: update component packages ``                                                  |
| [`4935a9a1`](https://github.com/NixOS/nixpkgs/commit/4935a9a1c7a3720c959392a7f5a7da94176a71b5) | `` python3Packages.samsung-exlink: init at 1.1.1 ``                                              |
| [`63267eed`](https://github.com/NixOS/nixpkgs/commit/63267eedfca1d556956d13d33e9f2dfc2f6573d3) | `` limine{,-full}: 12.6.1 -> 12.7.0 ``                                                           |
| [`6c3508c4`](https://github.com/NixOS/nixpkgs/commit/6c3508c4d5d71e1886005c19ff3eb15149e357e9) | `` github-desktop: 3.6.4 -> 3.6.5 ``                                                             |
| [`56e66903`](https://github.com/NixOS/nixpkgs/commit/56e66903aa4f5bf8e64a1450b4ec59fb31e4d68e) | `` vscode-css-languageserver: 1.105.0 -> 1.136.1 ``                                              |
| [`f1fb4105`](https://github.com/NixOS/nixpkgs/commit/f1fb4105de6bb73018145ffb4626b9b3a6ac4e42) | `` home-assistant: update component packages ``                                                  |
| [`4b92396f`](https://github.com/NixOS/nixpkgs/commit/4b92396f36c40fc6d12a043823d06997a6d4aa74) | `` python3Packages.nexblue-api: init at 0.1.3 ``                                                 |
| [`cc765d43`](https://github.com/NixOS/nixpkgs/commit/cc765d43c8aee2a7864da38bb19f72fe2470a977) | `` home-assistant: update component packages ``                                                  |
| [`7073bf3c`](https://github.com/NixOS/nixpkgs/commit/7073bf3ce7bf6bd92be15269e21870df0555bda7) | `` python3Packages.aiolibrenms: init at 0.0.3 ``                                                 |
| [`6fee384e`](https://github.com/NixOS/nixpkgs/commit/6fee384e6c0fc400d63dd999a82da84594e8a753) | `` pop-icon-theme: 3.5.0 -> 3.5.1 ``                                                             |
| [`ca6b8cf6`](https://github.com/NixOS/nixpkgs/commit/ca6b8cf67644d8ff03acf6742139d8fe6fe9efc1) | `` home-assistant: update component packages ``                                                  |
| [`4ed196cb`](https://github.com/NixOS/nixpkgs/commit/4ed196cb4f85fa996d9c43b00be097db8d41b603) | `` python3Packages.iseo-argo-ble: init at 0.9.6 ``                                               |
| [`a36e9940`](https://github.com/NixOS/nixpkgs/commit/a36e99401a1ee284c09386f5dcf5367b5bef839a) | `` lib.maintainers.eveeifyeve: update email, names and github ``                                 |
| [`3332411a`](https://github.com/NixOS/nixpkgs/commit/3332411a5b88b90817f4231f7ef61bedfa7aef0b) | `` fish: add functions to fish module ``                                                         |
| [`f1c61b42`](https://github.com/NixOS/nixpkgs/commit/f1c61b42da974041b180d34747305babc9e8407b) | `` zellijPlugins.zjframes: 0.24.0 -> 0.25.0 ``                                                   |
| [`13da66b6`](https://github.com/NixOS/nixpkgs/commit/13da66b66e11c9d46c50503b74703fd5d63eb4b9) | `` vimPlugins.visual-surround-nvim: init at 1.0.1 ``                                             |
| [`65d3d997`](https://github.com/NixOS/nixpkgs/commit/65d3d9975da18390ebee086aeaa7ddf7a8ff5417) | `` zellijPlugins.zjstatus: 0.24.0 -> 0.25.0 ``                                                   |
| [`23441009`](https://github.com/NixOS/nixpkgs/commit/234410092493829c05c5124d378a7f759f70986b) | `` editorconfig-checker: 3.11.1 -> 4.0.1 ``                                                      |
| [`265d6cda`](https://github.com/NixOS/nixpkgs/commit/265d6cda2cdf52ac3a6797d551d02118b737e66c) | `` rift-wm: 0.4.3 -> 0.5.5 ``                                                                    |
| [`09568a33`](https://github.com/NixOS/nixpkgs/commit/09568a339375e9fdec69a74c75bdcb779d5c0015) | `` rift-wm: add passthru.updateScript ``                                                         |
| [`74b72730`](https://github.com/NixOS/nixpkgs/commit/74b727301cb9495fecf93e7437e89ae18e457bdc) | `` home-assistant: update component packages ``                                                  |
| [`1d8b3c02`](https://github.com/NixOS/nixpkgs/commit/1d8b3c02428e1681e1ce2b00bba5def84f306fe9) | `` python3Packages.fronius-modbus: init at 0.2.0 ``                                              |
| [`ece67f99`](https://github.com/NixOS/nixpkgs/commit/ece67f990f47beee6b2d7d9bb0c588faf5b32387) | `` home-assistant: update component packages ``                                                  |
| [`989329ee`](https://github.com/NixOS/nixpkgs/commit/989329eea264d1caf433128270a82fd997f28e23) | `` python3Packages.flow-it-api: init at 0.0.1.1 ``                                               |
| [`292961bc`](https://github.com/NixOS/nixpkgs/commit/292961bc740de6c5b4ea6dbe64a73e1031441266) | `` pnpm: remove dead code used by dropped pnpm_8 ``                                              |
| [`2ecd4b8d`](https://github.com/NixOS/nixpkgs/commit/2ecd4b8d884abba4ca750e9006cd56fce6315e98) | `` bstring: 1.1.0 -> 1.1.1 ``                                                                    |
| [`cb2bce74`](https://github.com/NixOS/nixpkgs/commit/cb2bce74c46c31e643a9c255ef672a576c94cf5b) | `` home-assistant: update component packages ``                                                  |
| [`8548e341`](https://github.com/NixOS/nixpkgs/commit/8548e3412a345b4d80ccf72782a2edf35a7bdb7a) | `` python3Packages.flexit-modbus: init at 0.1.0 ``                                               |
| [`494092cf`](https://github.com/NixOS/nixpkgs/commit/494092cf15f925823f8567a3df245d572d4cd382) | `` ecspresso: 2.8.5 -> 2.8.6 ``                                                                  |
| [`eb2dd518`](https://github.com/NixOS/nixpkgs/commit/eb2dd5187dd37d440072cad2ea8f5d2d54fdfb5f) | `` python3Packages.boto3-stubs: 1.43.88 -> 1.43.89 ``                                            |
| [`ca275ff0`](https://github.com/NixOS/nixpkgs/commit/ca275ff0a3741204113f671126b79a9f1817a9d7) | `` python3Packages.mypy-boto3-service-quotas: 1.43.0 -> 1.43.89 ``                               |
| [`28e92388`](https://github.com/NixOS/nixpkgs/commit/28e9238863be40bdf15e88a31ef6e3778905d267) | `` python3Packages.mypy-boto3-mediatailor: 1.43.67 -> 1.43.89 ``                                 |
| [`1c1d61f4`](https://github.com/NixOS/nixpkgs/commit/1c1d61f4fbd064fa3998b7496a02988d58e72528) | `` python3Packages.mypy-boto3-ec2: 1.43.87 -> 1.43.89 ``                                         |
| [`cdfc8790`](https://github.com/NixOS/nixpkgs/commit/cdfc8790177231c8b720735fd48488bb4c852839) | `` python3Packages.caido-schema-proxy: 0.58.2 -> 0.58.3 ``                                       |
| [`1b3af71d`](https://github.com/NixOS/nixpkgs/commit/1b3af71d7c8282e315475ee5f4b5a2f2af658641) | `` python3Packages.boschshcpy: 0.6.8 -> 0.6.10 ``                                                |
| [`2e4bd216`](https://github.com/NixOS/nixpkgs/commit/2e4bd2166b42278e89fe89ea16cccbe17163f662) | `` ci/github-script/bot: fix pagination ``                                                       |
| [`9e47410a`](https://github.com/NixOS/nixpkgs/commit/9e47410adccc62e4c3ea2b41f3f7e1c86438c0b6) | `` python3Packages.alibabacloud-vpc20160428: 7.2.0 -> 7.2.1 ``                                   |
| [`c57b1e49`](https://github.com/NixOS/nixpkgs/commit/c57b1e49066e84e2d385cccb53ab55fb591d933b) | `` python3Packages.alibabacloud-sas20181203: 10.1.0 -> 10.1.2 ``                                 |
| [`dee68e4f`](https://github.com/NixOS/nixpkgs/commit/dee68e4fa78fc4a83d6b2a39b6b6a43e7eb98457) | `` python3Packages.validate-pyproject-schema-store: 2026.08.29 -> 2026.09.04 ``                  |
| [`89ad4c71`](https://github.com/NixOS/nixpkgs/commit/89ad4c718125e936c04d94711133c22366bf4ee9) | `` qovery-cli: 1.168.4 -> 1.169.0 ``                                                             |
| [`9d4511fe`](https://github.com/NixOS/nixpkgs/commit/9d4511fe2ce3cb050fb0426e371b4bf1fcbeb56a) | `` python3Packages.procmon-parser: 0.3.13 -> 0.4.0 ``                                            |
| [`0eb671d8`](https://github.com/NixOS/nixpkgs/commit/0eb671d8aabdc947e087f537f5906071335bdf66) | `` python3Packages.publicsuffixlist: 1.0.2.20260903 -> 1.0.2.20260904 ``                         |
| [`f2610602`](https://github.com/NixOS/nixpkgs/commit/f2610602774082b2747395bd6a71e6b1af9277e0) | `` python3Packages.resend: 2.42.0 -> 2.43.0 ``                                                   |
| [`28992443`](https://github.com/NixOS/nixpkgs/commit/28992443975cb6632286e7e0768ba886a5dc963c) | `` visual-paradigm-ce: 18.1.20260628 -> 18.1.20260838 ``                                         |
| [`6c1b954c`](https://github.com/NixOS/nixpkgs/commit/6c1b954c859cde08f9976bb74b514e4f9ed53929) | `` home-assistant: update component packages ``                                                  |
| [`2217cffa`](https://github.com/NixOS/nixpkgs/commit/2217cffa16154ee80cc1371fa69095a5db92a5cf) | `` python3Packages.besen: init at 0.3.4 ``                                                       |
| [`0cc6dca0`](https://github.com/NixOS/nixpkgs/commit/0cc6dca0df122649a8e627259d880c21b862dde3) | `` pico-sdk: 2.3.0 -> 2.3.1 ``                                                                   |
| [`bcbcabb0`](https://github.com/NixOS/nixpkgs/commit/bcbcabb086e28231af71fd058aac2a55c183b8b7) | `` postgresqlPackages.pgvectorscale: mark as broken on pg19 ``                                   |
| [`518a13e4`](https://github.com/NixOS/nixpkgs/commit/518a13e416ff073dc074152613cce9a60d67a41b) | `` postgresqlPackages.pgvectorscale: 0.9.0 -> 0.9.1 ``                                           |
| [`cafd2aca`](https://github.com/NixOS/nixpkgs/commit/cafd2aca63f1a01dd8a398e29b5401aa4a9b7d62) | `` renode-dts2repl: 0-unstable-2026-08-24 -> 0-unstable-2026-09-04 ``                            |
| [`6c1b8e04`](https://github.com/NixOS/nixpkgs/commit/6c1b8e04d4e68db30ba01bc9684c0d3f7c643079) | `` tvatprism: add tahlonbrahic as maintainer ``                                                  |
| [`71370611`](https://github.com/NixOS/nixpkgs/commit/7137061117a843f09c2db48509a56a983b6826e8) | `` python3Packages.python-manilaclient: 6.0.0 -> 6.3.0 ``                                        |
| [`ca4f0e4d`](https://github.com/NixOS/nixpkgs/commit/ca4f0e4d8b1fd27588e0d287d276c265bc726e89) | `` treewide: use nix-instantiate --eval --raw in update scripts ``                               |
| [`8d65ffa0`](https://github.com/NixOS/nixpkgs/commit/8d65ffa07998da4b48f9cfe1d22d7f0fdfde2223) | `` python3Packages.pysdl3: 0.9.11b1 -> 0.9.12b1 ``                                               |
| [`98d09aad`](https://github.com/NixOS/nixpkgs/commit/98d09aad60ea8dee63eea14d5603c0c6ba4e0f80) | `` ungoogled-chromium: 152.0.7977.75-1 -> 152.0.7977.82-1 ``                                     |
| [`8cc85b18`](https://github.com/NixOS/nixpkgs/commit/8cc85b1852f83243173cca8dc080645bb280c3c2) | `` ci/github-script/bot: log pagination cursor ``                                                |
| [`46e398b2`](https://github.com/NixOS/nixpkgs/commit/46e398b2c9f638080469a9d4e9d3206cae5dc4ad) | `` uxplay: 1.73.6 -> 1.73.7 ``                                                                   |
| [`b38d30c8`](https://github.com/NixOS/nixpkgs/commit/b38d30c84b5d2659f692e40463c9875a164e3227) | `` python3Packages.dateparser: 1.4.2 -> 1.4.3 ``                                                 |
| [`012d590a`](https://github.com/NixOS/nixpkgs/commit/012d590af8d85810304984232e133e19b5e2a429) | `` brutespray: 2.6.3 -> 2.7.2 ``                                                                 |
| [`0a37141b`](https://github.com/NixOS/nixpkgs/commit/0a37141b99f0e46d70a5512c749703990d20cee3) | `` famly-fetch: 0.6.0 -> 0.6.2 ``                                                                |
| [`c56110f0`](https://github.com/NixOS/nixpkgs/commit/c56110f0ef293cb4a0e96e1fcc24282990d6d0f3) | `` firefox-bin-unwrapped: 155.0 -> 155.0.1 ``                                                    |
| [`c1ae5d4f`](https://github.com/NixOS/nixpkgs/commit/c1ae5d4feee4c3d5b5480d0692bad7dc4d4edc8b) | `` firefox-unwrapped: 155.0 -> 155.0.1 ``                                                        |
| [`62774bf5`](https://github.com/NixOS/nixpkgs/commit/62774bf56e5f9443d8ff4dba9f39759e5f250e9a) | `` terraform-config-inspect: 0-unstable-2026-07-09 -> 0-unstable-2026-09-04 ``                   |
| [`e5f75c18`](https://github.com/NixOS/nixpkgs/commit/e5f75c185a9c9915817958035d407d20b5a97940) | `` i18next-cli: 1.71.3 -> 1.73.0 ``                                                              |
| [`dc556c86`](https://github.com/NixOS/nixpkgs/commit/dc556c86c89b4e9559a0de33fd442b44b8cd2a5b) | `` cliam: 1.63.2 -> 2.0.1 ``                                                                     |
| [`4dafc47b`](https://github.com/NixOS/nixpkgs/commit/4dafc47b3ccfc43c19161716de4f4cb42ff838c8) | `` tailcat: 0.3.0 -> 0.6.0 ``                                                                    |
| [`bfb57b6b`](https://github.com/NixOS/nixpkgs/commit/bfb57b6b8e7b6cd0040ebabee3a84b38c64b0567) | `` ovhcloud-cli: 0.13.0 -> 0.14.0 ``                                                             |
| [`e47cc79d`](https://github.com/NixOS/nixpkgs/commit/e47cc79d9d4a710dbcfc0ccb426820102fa0adf4) | `` python3Packages.nocaselist: remove six ``                                                     |
| [`17c837c3`](https://github.com/NixOS/nixpkgs/commit/17c837c3c3bd3618dd287598467be1e97348afbe) | `` python3Packages.nocaselist: migrate to finalAttrs ``                                          |
| [`5f0f172d`](https://github.com/NixOS/nixpkgs/commit/5f0f172d69bf01c3ce001f77f709a2df0cde76c0) | `` libretro.bsnes: 0-unstable-2026-08-12 -> 0-unstable-2026-09-04 ``                             |
| [`4df088a3`](https://github.com/NixOS/nixpkgs/commit/4df088a32997c1e37fc8c736bce7e3a6f271e193) | `` python3Packages.caldav: use finalAttrs ``                                                     |
| [`26058077`](https://github.com/NixOS/nixpkgs/commit/26058077354f48a9832cd2c73d8c46770c5c1117) | `` python3Packages.caldav: 3.2.1 -> 3.3.0 ``                                                     |
| [`d4017814`](https://github.com/NixOS/nixpkgs/commit/d4017814e55ef1e9644579d183eeac4945cc4427) | `` python3Packages.xformers: add GaetanLepage to maintainers ``                                  |
| [`42dacc78`](https://github.com/NixOS/nixpkgs/commit/42dacc78b16f5d07f91d0f52f61e7b717c939abe) | `` python3Packages.xformers: enable __structuredAttrs ``                                         |
| [`6e6d96e0`](https://github.com/NixOS/nixpkgs/commit/6e6d96e0517037afd1462f613343aa9acff9c143) | `` palera1n: fix checkra1n hashes per platform ``                                                |
| [`9cc68fa8`](https://github.com/NixOS/nixpkgs/commit/9cc68fa880d06c53173358253cef8954e20a879b) | `` home-assistant-custom-components.gtfs-realtime: fix tests ``                                  |
| [`f5be9f01`](https://github.com/NixOS/nixpkgs/commit/f5be9f01de6e4b100e908e25dff0620f38d5c6a3) | `` home-assistant-custom-components.frigate: 5.15.4 -> 5.15.6 ``                                 |
| [`05458de3`](https://github.com/NixOS/nixpkgs/commit/05458de336dd96019418db65c24611464c432528) | `` python3Packages.zigpy-zboss: 2.0.3 -> 2.0.5, patch to support zigpy 2.0 ``                    |
| [`1c55805e`](https://github.com/NixOS/nixpkgs/commit/1c55805e47ed1aa2d09e775bb0c02aa96e239f14) | `` python3Packages.sixel: fix pname ``                                                           |
| [`8a228de8`](https://github.com/NixOS/nixpkgs/commit/8a228de81d3123715d4d0f5cdec91f9f62170a1c) | `` home-assistant-custom-lovelace-modules.mushroom: 5.2.2 -> 5.2.3 ``                            |
| [`4a9d85b1`](https://github.com/NixOS/nixpkgs/commit/4a9d85b1bd19f540e0ce5aa528c562b17cd7c38b) | `` home-assistant-custom-lovelace-modules.multiple-entity-row: 4.10.1 -> 4.11.1 ``               |
| [`b950313f`](https://github.com/NixOS/nixpkgs/commit/b950313f3d95cbe71af7dee1f8fb676c7508d701) | `` home-assistant-custom-lovelace-modules.kiosk-mode: 14.0.2 -> 14.1.0 ``                        |
| [`72678e33`](https://github.com/NixOS/nixpkgs/commit/72678e3305545147368b6bb149d5c2fe5fec7cd4) | `` home-assistant-custom-lovelace-modules.custom-sidebar: 17.0.0 -> 17.1.0 ``                    |
| [`e7d3fe91`](https://github.com/NixOS/nixpkgs/commit/e7d3fe91facef753f6e99fa4fb931d1737a78239) | `` home-assistant-custom-lovelace-modules.custom-brand-icons: 2026.08.2 -> 2026.08.5 ``          |
| [`ac8e09bc`](https://github.com/NixOS/nixpkgs/commit/ac8e09bce6249d5dafe43e845f334d2a2aecbd4d) | `` home-assistant-custom-lovelace-modules.bubble-card: 3.2.5 -> 3.3.0 ``                         |
| [`c31b1847`](https://github.com/NixOS/nixpkgs/commit/c31b18477d07a41ea381b3369a81a092afc4f1fa) | `` home-assistant-custom-lovelace-modules.auto-entities: 2.6.1 -> 2.7.0 ``                       |
| [`de42d92c`](https://github.com/NixOS/nixpkgs/commit/de42d92c430c8081a405a8d064f6d16e574ddf00) | `` home-assistant-custom-components.xiaomi_gateway3: 4.2.1 -> 4.2.3 ``                           |
| [`ad70a032`](https://github.com/NixOS/nixpkgs/commit/ad70a0324cc610787f5f4f8f7176bded4c143c8e) | `` home-assistant-custom-components.tuya_local: 2026.8.1 -> 2026.9.0 ``                          |
| [`75b0da9b`](https://github.com/NixOS/nixpkgs/commit/75b0da9be9a606884f316eae75913b0089773a9f) | `` home-assistant-custom-components.tibber_local: 2026.8.1 -> 2026.9.0 ``                        |
| [`4c39e6f3`](https://github.com/NixOS/nixpkgs/commit/4c39e6f3dc38368b0960bc2a6db31737bae8e90b) | `` home-assistant-custom-components.spook: 5.0.0 -> 5.4.0 ``                                     |
| [`6840f8b6`](https://github.com/NixOS/nixpkgs/commit/6840f8b66e2dbdf228289f43603ecfffdea461eb) | `` home-assistant-custom-components.solax_modbus: 2026.08.2 -> 2026.09.1 ``                      |
| [`da139973`](https://github.com/NixOS/nixpkgs/commit/da139973ebb646d6687d40ea69f3105bd843c6d7) | `` home-assistant-custom-components.solarman: 25.08.16 -> 26.01.31 ``                            |
| [`82f21225`](https://github.com/NixOS/nixpkgs/commit/82f21225b65612a34367c805dc1e26c7dd9dd261) | `` home-assistant-custom-components.smarthq: 1.2.4 -> 1.3.0 ``                                   |
| [`06c79ea4`](https://github.com/NixOS/nixpkgs/commit/06c79ea42e388544abc12ac9d96d9417b304727a) | `` home-assistant-custom-components.midea_ac: 2026.8.2 -> 2026.8.3 ``                            |
| [`bfdc487d`](https://github.com/NixOS/nixpkgs/commit/bfdc487d55b12eaa12e9780f8c798cf6dc5e5d32) | `` home-assistant-custom-components.localthings: 0.24.0 -> 0.25.0 ``                             |
| [`36f6c1d3`](https://github.com/NixOS/nixpkgs/commit/36f6c1d3368d79a0b54502f4598a8fc7d82577af) | `` python3Packages.smartthings-local: 0.1.10 -> 0.1.14 ``                                        |
| [`bce2012b`](https://github.com/NixOS/nixpkgs/commit/bce2012b54817d2cdc671e71af88d5a5b29799ec) | `` home-assistant-custom-components.local_openai: 1.11.1 -> 1.12.0 ``                            |
| [`9978a0d7`](https://github.com/NixOS/nixpkgs/commit/9978a0d7641a4259c1368365a3b2ae60ef6ede99) | `` home-assistant-custom-components.fellow: 1.3.3 -> 2.0.0 ``                                    |
| [`9321752f`](https://github.com/NixOS/nixpkgs/commit/9321752f4628775773bf1d3ac96dc03b9c650a37) | `` home-assistant-custom-components.elegoo_printer: 2.12.0 -> 2.12.2 ``                          |
| [`58f0549e`](https://github.com/NixOS/nixpkgs/commit/58f0549eb8a3a2b22ca68de843e1ae90292741b5) | `` home-assistant-custom-components.ecoflow_ble: 1.0.4 -> 1.1.0 ``                               |
| [`c443c6d2`](https://github.com/NixOS/nixpkgs/commit/c443c6d2d9baebd7c3fc2f02ad95818a408a6833) | `` home-assistant-custom-components.better_thermostat: 1.8.2 -> 1.9.2 ``                         |
| [`2a50e126`](https://github.com/NixOS/nixpkgs/commit/2a50e126696eba841090aa8c1f815c7502e6187c) | `` home-assistant-custom-components.battery_notes: 3.6.0 -> 3.6.3 ``                             |
| [`48179216`](https://github.com/NixOS/nixpkgs/commit/481792160cc1053009d391ecb0410b121ae4907c) | `` home-assistant-custom-components.powercalc: 1.24.1 -> 1.25.3 ``                               |
| [`7f240307`](https://github.com/NixOS/nixpkgs/commit/7f240307aa8798b3221db1e08687e8a59ee2f6db) | `` home-assistant-custom-components.plant: 2026.8.1 -> 2026.9.0 ``                               |
| [`ce978eaf`](https://github.com/NixOS/nixpkgs/commit/ce978eaf20ceef5c876805f6537e6e43019faf57) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.357 -> 0.13.363 `` |
| [`5a7f8f78`](https://github.com/NixOS/nixpkgs/commit/5a7f8f78246b19c3d7317d9a4e279a8765efa298) | `` python3Packages.homeassistant-stubs: 2026.8.3 -> 2026.9.0 ``                                  |
| [`c27025dd`](https://github.com/NixOS/nixpkgs/commit/c27025ddd884cbadcc74b18e016f41cb96fd7416) | `` home-assistant: 2026.8.3 -> 2026.9.0 ``                                                       |
| [`6a07428b`](https://github.com/NixOS/nixpkgs/commit/6a07428bfd7da8f6c06a1dc9281bf3a93bcf41ea) | `` home-assistant.intents: 2026.7.30 -> 2026.8.28 ``                                             |
| [`a81c78b7`](https://github.com/NixOS/nixpkgs/commit/a81c78b7185cc57f92b6d4b9c78ace8c0ac5e9a3) | `` home-assistant.frontend: 20260729.7 -> 20260826.4 ``                                          |
| [`f1678e88`](https://github.com/NixOS/nixpkgs/commit/f1678e88428b100da07bb77b573203b483ba3fe7) | `` python3Packages.pyatv: fix tests with newest zeroconf ``                                      |
| [`19001e07`](https://github.com/NixOS/nixpkgs/commit/19001e07e58d8b3f3484dc309feea9474f178505) | `` python3Packages.zeroconf: 0.150.0 -> 0.151.3 ``                                               |
| [`bfbe474f`](https://github.com/NixOS/nixpkgs/commit/bfbe474f70fa8ce11f117186db80d4b5e2b258e5) | `` python3Packages.watergate-local-api: 2025.1.0 -> 2026.2.2 ``                                  |
| [`04bc8f68`](https://github.com/NixOS/nixpkgs/commit/04bc8f68fc9c8140527fbac13615f6b68b50e84e) | `` python3Packages.victron-mqtt: 2026.8.0 -> 2026.8.9 ``                                         |
| [`ae5b24e8`](https://github.com/NixOS/nixpkgs/commit/ae5b24e8feabea93ad6c385b54b9677ed7e12cad) | `` python3Packages.tuya-device-handlers: 0.0.26 -> 0.0.27 ``                                     |
| [`93b16314`](https://github.com/NixOS/nixpkgs/commit/93b16314fa2b4730ed187b90b773136be6b9bc03) | `` python3Packages.tesla-fleet-api: 1.7.6 -> 1.12.1 ``                                           |
| [`7a68a60a`](https://github.com/NixOS/nixpkgs/commit/7a68a60ade10dbcc473beaa36c7b0efa9fb85701) | `` python3Packages.tesla-protocol: init at 2.0.0 ``                                              |
| [`0b27c94d`](https://github.com/NixOS/nixpkgs/commit/0b27c94d3f413e61843afb5fde725ee86ef45522) | `` python3Packages.solaredge-web: 0.3.1 -> 0.4.0 ``                                              |
| [`acda1d33`](https://github.com/NixOS/nixpkgs/commit/acda1d3394047646dabe4dbaa404b9afed027fdf) | `` python3Packages.serialx: 1.8.2 -> 1.9.0 ``                                                    |
| [`1e30673b`](https://github.com/NixOS/nixpkgs/commit/1e30673ba60ed09275904f2498dca899eb7f5dd1) | `` python3Packages.reolink-aio: 0.21.9 -> 0.21.14 ``                                             |
| [`a531ed64`](https://github.com/NixOS/nixpkgs/commit/a531ed6415258ee1fb7e3da3629502bb7553dc16) | `` python3Packages.renault-api: 0.5.12 -> 0.5.13 ``                                              |
| [`355c14ee`](https://github.com/NixOS/nixpkgs/commit/355c14ee1f678c623e841962ecdd9ca4070e6766) | `` python3Packages.pytrafikverket: 1.1.1 -> 2.0.0 ``                                             |
| [`24e5a8c8`](https://github.com/NixOS/nixpkgs/commit/24e5a8c8a74b77d8bc9613342331cf281022b0de) | `` python3Packages.yalexs: 9.2.10 -> 9.2.13 ``                                                   |
| [`883e57c8`](https://github.com/NixOS/nixpkgs/commit/883e57c8790a1909ce8f011dd14369353912e6ca) | `` python3Packages.xiaomi-ble: 1.15.0 -> 1.16.0 ``                                               |
| [`89617920`](https://github.com/NixOS/nixpkgs/commit/8961792070bf4ae504e3b98fd3ad72e35d600d7a) | `` python3Packages.voip-utils: 0.4.0 -> 0.4.3 ``                                                 |
| [`20b2d616`](https://github.com/NixOS/nixpkgs/commit/20b2d616c1e7bc48ebc7e40f35d36630b990f3b4) | `` python3Packages.pythonkuma: 0.5.1 -> 0.5.2 ``                                                 |
| [`070b5578`](https://github.com/NixOS/nixpkgs/commit/070b557835e32796b1f0786f40cae319cc5f4aee) | `` python3Packages.python-openevse-http: 1.0.1 -> 1.5.0 ``                                       |
| [`2c202149`](https://github.com/NixOS/nixpkgs/commit/2c2021491fbf31ca77a2e7cc9ce29cbbebee5483) | `` python3Packages.pystiebeleltron: 0.6.2 -> 0.7.0 ``                                            |
| [`78929871`](https://github.com/NixOS/nixpkgs/commit/789298711f73ec7b4dd3b98f31e9723d5c1828b5) | `` python3Packages.modbus-connection: 3.9.0 -> 4.10.0 ``                                         |
| [`bc3e14ae`](https://github.com/NixOS/nixpkgs/commit/bc3e14ae92e4ab79e3a218471240b8e7917f9d3d) | `` python3Packages.tmodbus: 0.5.1 -> 0.6.1 ``                                                    |
| [`2fb19b8c`](https://github.com/NixOS/nixpkgs/commit/2fb19b8cd2b468ee97d75d09efa7331b64e32ecd) | `` python3Packages.pymodbus: 3.14.0 -> 3.15.0 ``                                                 |
| [`fb9aeb8d`](https://github.com/NixOS/nixpkgs/commit/fb9aeb8daa82cdefa00cde838f9424b341d26841) | `` python3Packages.pyhik: 0.4.3 -> 0.4.5 ``                                                      |
| [`19add5d0`](https://github.com/NixOS/nixpkgs/commit/19add5d081cfa61cd7e04acee18ea8caa7565df1) | `` python3Packages.pydaikin: 2.18.4 -> 2.19.0 ``                                                 |
| [`add4c0e7`](https://github.com/NixOS/nixpkgs/commit/add4c0e766be6bf6c1077e00a7cc068c062467a5) | `` python3Packages.pyatmo: 9.6.0 -> 9.9.1 ``                                                     |
| [`c63e36bd`](https://github.com/NixOS/nixpkgs/commit/c63e36bd02ea4a1a119289dda1da8952376ca129) | `` python3Packages.powerfox: 2.1.2 -> 2.1.3 ``                                                   |
| [`f4991892`](https://github.com/NixOS/nixpkgs/commit/f49918920965a8c3a4cfadd5fe655baeff420d3f) | `` python3Packages.knx-frontend: 2026.8.2.133643 -> 2026.8.28.62336 ``                           |
| [`c8861814`](https://github.com/NixOS/nixpkgs/commit/c8861814208e007080c802bc2b7e7eb81ae74347) | `` python3Packages.habluetooth: 6.26.5 -> 6.26.11 ``                                             |
| [`20cc040a`](https://github.com/NixOS/nixpkgs/commit/20cc040a0d47cef85f86286ec473e51e70a90a94) | `` python3Packages.google-nest-sdm: 9.1.2 -> 9.2.1 ``                                            |
| [`890ff3bd`](https://github.com/NixOS/nixpkgs/commit/890ff3bdb1d0e64874b179d1390797fab0e5b378) | `` python3Packages.python-technove: 2.1.2 -> 2.1.3 ``                                            |
| [`12394d6e`](https://github.com/NixOS/nixpkgs/commit/12394d6e06316ee1ea1076475c86bbb9f79b4991) | `` python3Packages.python-roborock: 5.31.1 -> 7.1.1 ``                                           |
| [`982c9991`](https://github.com/NixOS/nixpkgs/commit/982c99910d873c9251e60c199275d39eda1e34e7) | `` python3Packages.python-izone: 1.3.9 -> 1.3.10 ``                                              |
| [`302bbae4`](https://github.com/NixOS/nixpkgs/commit/302bbae4e211ba13d979a475b811ce18b6299fca) | `` python3Packages.peblar: 0.5.1 -> 1.0.1 ``                                                     |
| [`158956c9`](https://github.com/NixOS/nixpkgs/commit/158956c9c61ac48a068535a99819d2875dbadccd) | `` python3Packages.lunatone-rest-api-client: 0.9.2 -> 0.10.0 ``                                  |
| [`0c8ade8a`](https://github.com/NixOS/nixpkgs/commit/0c8ade8a26bda58de34d946e1db89d1b1ca688d7) | `` Revert "python3Packages.orjson: 3.11.9 -> 3.12.0" ``                                          |
| [`38ac53a2`](https://github.com/NixOS/nixpkgs/commit/38ac53a2fdd8a3690d5094f0f050a9e4b14d240d) | `` python3Packages.orjson: 3.11.9 -> 3.12.0 ``                                                   |
| [`f5cab012`](https://github.com/NixOS/nixpkgs/commit/f5cab0129d52f0eaa3d0c030bcc14c74cf54b4cf) | `` python3Packages.hassil: 3.11.0 -> 3.12.0 ``                                                   |
| [`52a6be38`](https://github.com/NixOS/nixpkgs/commit/52a6be38bbfd2a5632c58996961588ae9486891c) | `` python3Packages.music-assistant-models: 1.1.152 -> 1.1.189 ``                                 |
| [`22119305`](https://github.com/NixOS/nixpkgs/commit/2211930569540b3b310b45e30b1ad0b935069428) | `` python3Packages.music-assistant-client: 1.4.3 -> 1.5.1 ``                                     |
| [`e4dfcd0f`](https://github.com/NixOS/nixpkgs/commit/e4dfcd0f0a55e9564752d3794fc9050e19a70401) | `` python314Packages.zha-quirks: 2.2.0 -> 2.2.1 ``                                               |
| [`fd8c69c0`](https://github.com/NixOS/nixpkgs/commit/fd8c69c040fbf5620e9256d05a244ecbffa0fee9) | `` zigpy-cli: 1.2.1 -> 2.0.0 ``                                                                  |
| [`2e564087`](https://github.com/NixOS/nixpkgs/commit/2e56408777559b1a506e76ef465f4c3c0924d4b1) | `` python3Packages.zigpy-xbee: 0.21.1 -> 0.22.0 ``                                               |
| [`d166aa70`](https://github.com/NixOS/nixpkgs/commit/d166aa70dfa51044ef852a115c595b285a0618ee) | `` python3Packages.zha: 2.1.0 -> 2.2.1 ``                                                        |
| [`c7b02156`](https://github.com/NixOS/nixpkgs/commit/c7b021565d4a63ed211c4c1b9016ecc56bf1cb2e) | `` python3Packages.bellows: 1.0.0 -> 1.0.1 ``                                                    |
| [`0afaa596`](https://github.com/NixOS/nixpkgs/commit/0afaa5969853d13e648f1f78655a7446a728cc93) | `` python3Packages.hass-nabucasa: 2.2.0 -> 2.7.0 ``                                              |
| [`f36a9934`](https://github.com/NixOS/nixpkgs/commit/f36a9934711965579e563dc73c4bc5c00de5a25c) | `` python3Packages.snitun: 0.45.1 -> 0.47.0 ``                                                   |
| [`5c99ba61`](https://github.com/NixOS/nixpkgs/commit/5c99ba61f8b2a6f39a7a0c4586fe6631c801edc7) | `` python3Packages.google-genai: 1.67.0 -> 2.16.0 ``                                             |
| [`83fb527f`](https://github.com/NixOS/nixpkgs/commit/83fb527f0f14eb64f3a2b003eae05217f4ffe6a0) | `` nixos/pdfding: remove s3 backups feature ``                                                   |
| [`8a4dcd69`](https://github.com/NixOS/nixpkgs/commit/8a4dcd69ec1fe49ab0fac6df8ec5dd0fe0a2076f) | `` python3Packages.derpconf: drop ``                                                             |
| [`b5102233`](https://github.com/NixOS/nixpkgs/commit/b51022332fe01f0da5fb1a5d51f4272bfcef1c10) | `` egl-wayland2: 1.0.1 -> 1.0.2 ``                                                               |
| [`775afc1d`](https://github.com/NixOS/nixpkgs/commit/775afc1dbc041bd3a4de321fa7988e7fb91dc207) | `` git-pages.services.default: init ``                                                           |
| [`39b29a23`](https://github.com/NixOS/nixpkgs/commit/39b29a23c7ec0170095cecbefd634d7b0f44bed5) | `` noctalia: run versionCheckHook ``                                                             |
| [`83ba5b6e`](https://github.com/NixOS/nixpkgs/commit/83ba5b6ef04ad6e5bc296b39b1338f87d498d6d9) | `` noctalia-greeter: Run versionCheckHook ``                                                     |
| [`9c242d8d`](https://github.com/NixOS/nixpkgs/commit/9c242d8db28dac072674a8556b19431c718a1c74) | `` paperless-ngx: 3.1.1 -> 3.1.3 ``                                                              |
| [`2b4eaf56`](https://github.com/NixOS/nixpkgs/commit/2b4eaf569b46efffe6f0f7d3b751d0783697a8ea) | `` nomacs: fix darwin build ``                                                                   |
| [`600fe1e1`](https://github.com/NixOS/nixpkgs/commit/600fe1e1c8cb939da6bc78afd11328bc873b4ece) | `` fastmail-desktop: add maintainer ``                                                           |
| [`76362535`](https://github.com/NixOS/nixpkgs/commit/7636253553d5696fb4afce5d18d75f40256e6c17) | `` ddns-go: 6.17.6 -> 6.17.7 ``                                                                  |
| [`c475ad21`](https://github.com/NixOS/nixpkgs/commit/c475ad2107fb6e843f489f684d10ba48224d3b74) | `` python3Packages.fumis: 0.4.0 -> 0.4.1 ``                                                      |
| [`8d7aeca7`](https://github.com/NixOS/nixpkgs/commit/8d7aeca77db8303c52948fad5491cd213bfbddef) | `` python3Packages.brother: 6.1.1 -> 6.1.2 ``                                                    |
| [`316523c4`](https://github.com/NixOS/nixpkgs/commit/316523c489a03b1563c22df427f5b01e365465e4) | `` python3Packages.bluetooth-data-tools: 1.29.18 -> 1.29.24 ``                                   |
| [`d0c714af`](https://github.com/NixOS/nixpkgs/commit/d0c714afb452c14774a1e8f28c0942e8a5ebc172) | `` python3Packages.bleak-retry-connector: 4.6.3 -> 4.7.0 ``                                      |
| [`722e2e01`](https://github.com/NixOS/nixpkgs/commit/722e2e01d2b1849aa1b1a542432f4d23d44fce76) | `` home-assistant.python3Packages.gazetteer-matcher: init at 1.1.0 ``                            |
| [`aa8a6d2e`](https://github.com/NixOS/nixpkgs/commit/aa8a6d2ea032e9057619a2c28c53608d198758ed) | `` python3Packages.energyzero: 4.0.1 -> 5.0.2 ``                                                 |
| [`27876bb5`](https://github.com/NixOS/nixpkgs/commit/27876bb52336c67d450d8b2efa5a89e566ae2233) | `` python3Packages.bleak-esphome: 3.9.7 -> 4.1.0 ``                                              |
| [`8edc675c`](https://github.com/NixOS/nixpkgs/commit/8edc675ce51d62d990249b6e1b4dfa46738d0fde) | `` python3Packages.airgradient: 0.9.2 -> 0.10.0 ``                                               |
| [`0d783f0c`](https://github.com/NixOS/nixpkgs/commit/0d783f0c1fdbef28d8c7cb6da2ee8c2dea2a4536) | `` python3Packages.aiowebostv: 0.9.2 -> 0.10.0 ``                                                |
| [`7d68322c`](https://github.com/NixOS/nixpkgs/commit/7d68322c97d4bc075da3456708aeae0d6638c542) | `` python3Packages.aiomodernforms: 0.1.8 -> 0.2.0 ``                                             |
| [`8cbfb1a1`](https://github.com/NixOS/nixpkgs/commit/8cbfb1a1a70b20b4f8e3cba6d45deb6f508d4abd) | `` python3Packages.aioesphomeapi: 45.12.0 -> 46.3.0 ``                                           |
| [`0fc06a3a`](https://github.com/NixOS/nixpkgs/commit/0fc06a3a6e424f417e8ee39a081bba8fbfb7c337) | `` python3Packages.aioamazondevices: 14.2.2 -> 15.1.0 ``                                         |
| [`20a8e3a6`](https://github.com/NixOS/nixpkgs/commit/20a8e3a6be080bda6f4b271f60cb6e3f2b06dfc1) | `` python3Packages.syrupy_6: init at 6.0.0 ``                                                    |
| [`715b4315`](https://github.com/NixOS/nixpkgs/commit/715b4315c91c3a5c38d72cc3d17fc7f498d89491) | `` wyoming-faster-whisper: 3.6.0 -> 3.7.0 ``                                                     |
| [`eac82449`](https://github.com/NixOS/nixpkgs/commit/eac82449552400617463a887836147b7ba71ae55) | `` opencode: 1.18.25 -> 1.18.28 ``                                                               |
| [`79a42735`](https://github.com/NixOS/nixpkgs/commit/79a427358066ff19d106c6c2ecd45c09fbed9543) | `` terraform-providers.hashicorp_google: 7.45.0 -> 8.1.0 ``                                      |
| [`8f141825`](https://github.com/NixOS/nixpkgs/commit/8f1418250f0d769d03f07a95732a477a277292d1) | `` vscode: 1.135.0 -> 1.136.1 ``                                                                 |
| [`3fd8477e`](https://github.com/NixOS/nixpkgs/commit/3fd8477ef3ebab9d5e9e7553e06023ab9ed68fd4) | `` git-pkgs: 0.19.0 -> 0.20.0 ``                                                                 |
| [`bc4f7c6d`](https://github.com/NixOS/nixpkgs/commit/bc4f7c6dfec08e5b2583b8aed89ef72bd49bb5cd) | `` jj-starship: 0.7.1 -> 0.7.3 ``                                                                |
| [`36b8fda0`](https://github.com/NixOS/nixpkgs/commit/36b8fda00b618569a50f2239c8ef8a8a7b422d70) | `` hickory-dns: 0.26.1 -> 0.26.2 ``                                                              |
| [`0b440830`](https://github.com/NixOS/nixpkgs/commit/0b4408304663a6a0ef2891858f48f1878c588894) | `` python3Packages.nocaselist: 2.2.0 -> 2.2.1 ``                                                 |
| [`35e91e78`](https://github.com/NixOS/nixpkgs/commit/35e91e789342ab544db373cd1578b6e3dfd279c1) | `` omnictl: 1.10.5 -> 1.10.6 ``                                                                  |
| [`f9037a01`](https://github.com/NixOS/nixpkgs/commit/f9037a0116551f3bb0534c3c22b53741ff7e2cd6) | `` conan: 2.31.2 -> 2.32.0 ``                                                                    |
| [`e4c5854d`](https://github.com/NixOS/nixpkgs/commit/e4c5854d56b8f06187a02269f0cc66c63c6de02d) | `` python3Packages.pyscf: cleanup, re-enable on aarch64-linux ``                                 |
| [`e13f77c9`](https://github.com/NixOS/nixpkgs/commit/e13f77c993f6e72c080cccacd9db98935a6063be) | `` pegasus-frontend: 2024-11-11 -> 2026-07-18 ``                                                 |
| [`a6df94e8`](https://github.com/NixOS/nixpkgs/commit/a6df94e8e26901238e7eba9af638ef464f891c39) | `` pegasus-frontend: add irgolic as maintainer ``                                                |
| [`b19bda4d`](https://github.com/NixOS/nixpkgs/commit/b19bda4d319d96137468918bc429d1ec67761e9a) | `` libretro.fuse: 0-unstable-2026-08-12 -> 0-unstable-2026-09-01 ``                              |
| [`d845c0b3`](https://github.com/NixOS/nixpkgs/commit/d845c0b3e05d9c8cb83fe1826ca183c56d3273fe) | `` maintainers: add irgolic ``                                                                   |
| [`ca9fd7b7`](https://github.com/NixOS/nixpkgs/commit/ca9fd7b73e2a2344956b4ce61718456eabccc0b9) | `` python3Packages.google-cloud-container: migrate to finalAttrs ``                              |
| [`ad8b523f`](https://github.com/NixOS/nixpkgs/commit/ad8b523f9b161b688811184c93ea6edc2395fc3e) | `` mate-utils: 1.28.1 -> 1.28.3 ``                                                               |
| [`1383b536`](https://github.com/NixOS/nixpkgs/commit/1383b536c1046fcbb6d3da8ffcc649558b17d575) | `` xmpp-bridge: drop ``                                                                          |
| [`98e28dc0`](https://github.com/NixOS/nixpkgs/commit/98e28dc0d0fe0f128eaaaca05bc81fecc90affb9) | `` protoc-gen-twirp_swagger: add throw alias for deletion ``                                     |
| [`9089b2ee`](https://github.com/NixOS/nixpkgs/commit/9089b2eee9162254a00d06e2be84790a26d94b5c) | `` rofi-pass: add throw alias for deletion ``                                                    |
| [`20c96d92`](https://github.com/NixOS/nixpkgs/commit/20c96d92785229724fd7a8205fbb38411517ff9a) | `` nailgun: add throw alias for deletion ``                                                      |
| [`1c7299ef`](https://github.com/NixOS/nixpkgs/commit/1c7299ef12a2a72fdc0302f675b63e2269453f79) | `` wasynth: add throw alias for deletion ``                                                      |
| [`83f0467f`](https://github.com/NixOS/nixpkgs/commit/83f0467fb880eb39d6e493d7d7a998f2c3f41a53) | `` gshogi: add throw alias for deletion ``                                                       |
| [`1849df60`](https://github.com/NixOS/nixpkgs/commit/1849df600659be2d9657c248582fc88f95cfebf8) | `` pkgs/open-interpreter: add happysalada to maintainers ``                                      |
| [`00df64e6`](https://github.com/NixOS/nixpkgs/commit/00df64e61ace7bd094797a913a702dc95ff0da9b) | `` pgformatter: 5.10 -> 5.11 ``                                                                  |
| [`50814d5a`](https://github.com/NixOS/nixpkgs/commit/50814d5ac49e1884a0db083cda9ddacdcd91f3f4) | `` python3Packages.pyswitchbot: 2.6.0 -> 2.7.0 ``                                                |
| [`632ade99`](https://github.com/NixOS/nixpkgs/commit/632ade991921fd19fc1147a52621a150d01b79ee) | `` renderizer: add throw alias for deletion ``                                                   |
| [`50d37040`](https://github.com/NixOS/nixpkgs/commit/50d3704072ce4c6582c2d7c676659bfa04e5c419) | `` garmintools: add throw alias for deletion ``                                                  |
| [`ea97702f`](https://github.com/NixOS/nixpkgs/commit/ea97702f4ced6f65e7c81f642395a9b9d7a0fa34) | `` htb-toolkit: add throw alias for deletion ``                                                  |
| [`1883d8f6`](https://github.com/NixOS/nixpkgs/commit/1883d8f66456466660c60902bfe5eaadb92d81fa) | `` bitcoin-knots: 29.3.knots20260508 -> 29.4.1.knots20260508 ``                                  |
| [`05b835b7`](https://github.com/NixOS/nixpkgs/commit/05b835b7d2532c7be3d7d855c6b5598fd08b5c36) | `` python3Packages.xformers: fix build with pytorch 2.13 ``                                      |
| [`cfdbd126`](https://github.com/NixOS/nixpkgs/commit/cfdbd126ba3341ac4c0a46bd014c5fac640a0172) | `` falcoctl: 0.13.0 -> 0.14.0 ``                                                                 |
| [`3487aa29`](https://github.com/NixOS/nixpkgs/commit/3487aa29ed08f88e4e566c84dcbaf8a81f58d8a9) | `` release-plz: 0.3.160 -> 0.3.161 ``                                                            |
| [`bb67458d`](https://github.com/NixOS/nixpkgs/commit/bb67458d285e29dbdb29c17ba002cf52400fe60e) | `` binaryninja-free: 5.2.8722 -> 6.0.10601 ``                                                    |
| [`6ab4307d`](https://github.com/NixOS/nixpkgs/commit/6ab4307de0ccbbb2c51a36ec3610280fcfebd433) | `` perfetto-sdk: init at 58.3 ``                                                                 |
| [`76b15677`](https://github.com/NixOS/nixpkgs/commit/76b1567768a0d107cd363653384667cce82e4775) | `` kor: 0.6.8 -> 0.6.9 ``                                                                        |
| [`9ace62b4`](https://github.com/NixOS/nixpkgs/commit/9ace62b45a4da9ace982186367928d520acb6de8) | `` zrc: 2.7 -> 2.8 ``                                                                            |
| [`f255f660`](https://github.com/NixOS/nixpkgs/commit/f255f660933212d98f5552df60067f98a99d05d1) | `` python3Packages.google-cloud-container: 2.65.0 -> 2.66.0 ``                                   |
| [`e19b3794`](https://github.com/NixOS/nixpkgs/commit/e19b379433cb5e9049441d365597554fcc33cd36) | `` just-lsp: 0.6.2 -> 0.7.1 ``                                                                   |
| [`361c7e36`](https://github.com/NixOS/nixpkgs/commit/361c7e367edd5c01f1b3c77e6a7fb45f7f8dc1bf) | `` pkgs/trivial-builders: convert comments to doc-comments ``                                    |
| [`56970aef`](https://github.com/NixOS/nixpkgs/commit/56970aefe487e2a3dbf0e0e22bbbae69b4a57ebd) | `` python3Packages.aiopnsense: 1.1.7 -> 1.1.9 ``                                                 |
| [`54d416da`](https://github.com/NixOS/nixpkgs/commit/54d416dac9126f1f7768159adc264bab93ba3215) | `` python3Packages.pysnmp-pyasn1: 1.1.3 -> 1.2.0 ``                                              |
| [`bafb82c9`](https://github.com/NixOS/nixpkgs/commit/bafb82c9e23e54f048941ed0b42e7a45af0b03ef) | `` sub-store-frontend: 2.29.10 -> 2.31.1 ``                                                      |
| [`ea14b925`](https://github.com/NixOS/nixpkgs/commit/ea14b92582507bd9ff301ed12b0af6ae79153461) | `` pdfding: 1.13.0 -> 1.14.0 ``                                                                  |
| [`8d1f9c15`](https://github.com/NixOS/nixpkgs/commit/8d1f9c151b4071526d2e458e5546c389ddb8f946) | `` qownnotes-tui: 0.6.0 -> 0.8.0 ``                                                              |
| [`eb9e0a71`](https://github.com/NixOS/nixpkgs/commit/eb9e0a713283589dd36b80483411129491547802) | `` krep: 3.0.1 -> 3.0.2 ``                                                                       |
| [`47cffa9b`](https://github.com/NixOS/nixpkgs/commit/47cffa9ba43e3ab204dcff7fea6eb47757ca08fb) | `` plakar: 1.1.4 -> 1.1.5 ``                                                                     |
| [`23d6cc1f`](https://github.com/NixOS/nixpkgs/commit/23d6cc1f49d04f13c44965d8c3b24f33a094ffc7) | `` openscadPackages.bosl2: 2.0.751 -> 2.0.752 ``                                                 |
| [`e3ccc1eb`](https://github.com/NixOS/nixpkgs/commit/e3ccc1eb5bf76432121190b93c31edb7793063da) | `` python3Packages.qcelemental: 0.50.4 -> 0.51.1 ``                                              |
| [`0644cac4`](https://github.com/NixOS/nixpkgs/commit/0644cac4a8b3580269446eb1bbdd17fd0ac1339a) | `` miru: 0.7.0 -> 0.8.0 ``                                                                       |
| [`07facdfc`](https://github.com/NixOS/nixpkgs/commit/07facdfc27dc4025a58da8cad4ad5dc8bbdd892d) | `` mtail: 3.4.9 -> 3.4.10 ``                                                                     |
| [`9449e2d2`](https://github.com/NixOS/nixpkgs/commit/9449e2d2de506ba72ca3159383b43ad3efa24d9f) | `` drupal: 11.4.5 -> 11.4.6 ``                                                                   |
| [`d56cacad`](https://github.com/NixOS/nixpkgs/commit/d56cacade12512068609d396b5a19330e4cee5cd) | `` prek: 0.4.14 -> 0.5.2 ``                                                                      |
| [`05c0b9c0`](https://github.com/NixOS/nixpkgs/commit/05c0b9c01c35654f01dc7d6a48fe0d091dbbe74a) | `` python3Packages.ua-generator: 2.1.3 -> 2.1.4 ``                                               |
| [`cbcc7656`](https://github.com/NixOS/nixpkgs/commit/cbcc7656b8a22ebc57639a305ea248ea3c87fea2) | `` python3Packages.aioaquarite: 0.8.0 -> 0.12.2 ``                                               |
| [`59bfe2b5`](https://github.com/NixOS/nixpkgs/commit/59bfe2b5e2f6b6eb5287bc916e95f51155c70e78) | `` python3Packages.pydanfossair: enable tests ``                                                 |
| [`ba2884b3`](https://github.com/NixOS/nixpkgs/commit/ba2884b3a7f57775f395eef543b12712037ca860) | `` rumdl: 0.2.60 -> 0.2.64 ``                                                                    |
| [`7d439f04`](https://github.com/NixOS/nixpkgs/commit/7d439f040ba94dc6329159c5b0d0ab3f74c15294) | `` python3Packages.pydanfossair: migrate to finalAttrs ``                                        |
| [`7ad5dbaa`](https://github.com/NixOS/nixpkgs/commit/7ad5dbaafceedd7aab092bb9fed4718ebf62b4ae) | `` user-scanner: 1.4.3.1 -> 1.5.1 ``                                                             |
| [`00670641`](https://github.com/NixOS/nixpkgs/commit/0067064153f43f3aa985aefafcef5c868d5f6cf0) | `` ranger: 1.9.4-unstable-2026-08-15 -> 1.9.4-unstable-2026-08-31 ``                             |
| [`a9bdaf3e`](https://github.com/NixOS/nixpkgs/commit/a9bdaf3e6308c3a1ab640f57f297338bebfa85bc) | `` python3Packages.cyclopts: 4.23.3 -> 4.24.0 ``                                                 |
| [`8e75c089`](https://github.com/NixOS/nixpkgs/commit/8e75c089a1ba60363c0d99bcd7553d50628580f0) | `` python3Packages.credsweeper: 1.18.1 -> 1.18.2 ``                                              |
| [`7885e7c7`](https://github.com/NixOS/nixpkgs/commit/7885e7c742e2a740a090c688d2207286103f1388) | `` python3Packages.claude-agent-sdk: 0.2.149 -> 0.2.152 ``                                       |
| [`87074244`](https://github.com/NixOS/nixpkgs/commit/87074244b4065ebdc36b8d07817f4a8dc936be6f) | `` python3Packages.alibabacloud-sls20201230: 5.14.0 -> 5.15.0 ``                                 |
| [`e86b50a3`](https://github.com/NixOS/nixpkgs/commit/e86b50a3f5c46004158015d2df21d34303665efc) | `` exploitdb: 2026-09-02 -> 2026-09-03 ``                                                        |
| [`64c91c29`](https://github.com/NixOS/nixpkgs/commit/64c91c29ec6b6ee35be3a759a31025d446c016f4) | `` mango: 0.16.2 -> 0.16.3 ``                                                                    |
| [`48774b6a`](https://github.com/NixOS/nixpkgs/commit/48774b6a3cba07faf20abc679dac6256b83850b2) | `` chisel: 1.12.0 -> 1.12.1 ``                                                                   |
| [`5c7cc186`](https://github.com/NixOS/nixpkgs/commit/5c7cc186c4626630bbd2e3e45a120324093fd155) | `` knot-dns: 3.5.7 -> 3.5.8 ``                                                                   |
| [`ba083f27`](https://github.com/NixOS/nixpkgs/commit/ba083f2756f70bd797e9c4e8f268bb8837c8fa14) | `` doc/nav: use id-prefix for autogenerated docs ``                                              |
| [`1656aee6`](https://github.com/NixOS/nixpkgs/commit/1656aee6d7053dd5cfa69cf91bbecd0e27404db1) | `` pkgs/nixos-render-docs: support id-prefix for configLeaf ``                                   |
| [`6f88f787`](https://github.com/NixOS/nixpkgs/commit/6f88f7876719c16e80de338df370605f8b05f5fa) | `` doc/treewide: migrate inline includes to nav.json ``                                          |
| [`709ef6dd`](https://github.com/NixOS/nixpkgs/commit/709ef6ddacd7cb53279816e1cc13361c7d55a06b) | `` python3Packages.pydanfossair: 0.3.0 -> 1.0.0 ``                                               |
| [`8c6681fb`](https://github.com/NixOS/nixpkgs/commit/8c6681fb46c4ab1921b40ab3d66012603253ec04) | `` doc: add one-shot include-to-nav conversion script ``                                         |
| [`a9510553`](https://github.com/NixOS/nixpkgs/commit/a95105539d691fcbc275396dca50a334b99ab810) | `` matrix-authentication-service: 1.23.0 -> 1.24.0 ``                                            |
| [`06aa7fcd`](https://github.com/NixOS/nixpkgs/commit/06aa7fcdaa390ad9eb63ded95f235a9f9b271183) | `` pgmetrics: 1.19.0 -> 1.19.1 ``                                                                |
| [`0c766dea`](https://github.com/NixOS/nixpkgs/commit/0c766dea176ce5fbaf3a7b16e308643559c23a6e) | `` adb-sync: drop ``                                                                             |
| [`f6e3d98f`](https://github.com/NixOS/nixpkgs/commit/f6e3d98fb9af8635f59099ac66c24d2f3f736741) | `` r128gain: drop ``                                                                             |
| [`337cd2ec`](https://github.com/NixOS/nixpkgs/commit/337cd2ec8de9d948c20c232423cc88c354889dca) | `` prototool: drop ``                                                                            |
| [`bd0e5d01`](https://github.com/NixOS/nixpkgs/commit/bd0e5d0150c7afb3a3a709d181b8358c0f8dd1f0) | `` home-assistant-custom-components.smarthq: 1.2.4 -> 1.3.0 ``                                   |
| [`0ea64b4f`](https://github.com/NixOS/nixpkgs/commit/0ea64b4fce24686993723c1d437746c8761ebe58) | `` brise: drop ``                                                                                |
| [`a5eac1af`](https://github.com/NixOS/nixpkgs/commit/a5eac1af8e9cf1aa3099f7b4ba9d7a890bfdc458) | `` python3Packages.pydriller: 2.10 -> 2.11 ``                                                    |
| [`54294836`](https://github.com/NixOS/nixpkgs/commit/5429483633b836cb33160486069941c03ba59afd) | `` zed: drop ``                                                                                  |
| [`e74aabbc`](https://github.com/NixOS/nixpkgs/commit/e74aabbc77662b71412457dfd91e7eb524bb7768) | `` oci-cli: 3.91.0 -> 3.92.0 ``                                                                  |
| [`a56c546e`](https://github.com/NixOS/nixpkgs/commit/a56c546e3ca80e772cfc996aeb5a59c539d5f338) | `` garmintools: drop ``                                                                          |
| [`2ba77e1f`](https://github.com/NixOS/nixpkgs/commit/2ba77e1f3c7e41c16c7a9616d6f1e3be007e69e7) | `` mvapich: add rocm and cuda support ``                                                         |
| [`554553bd`](https://github.com/NixOS/nixpkgs/commit/554553bdc25f687531ae714647b176bf9a9fe345) | `` microsoft-edge: 152.0.4191.53 -> 152.0.4191.62 ``                                             |
| [`01a056bd`](https://github.com/NixOS/nixpkgs/commit/01a056bd0b65f7dbfebda2cf907a07ffd4988d3b) | `` rush-lyrics: 6.6.0 -> 6.6.1 ``                                                                |
| [`5bf662c8`](https://github.com/NixOS/nixpkgs/commit/5bf662c854c6178cd8131fb83b6021b809291b88) | `` typescript-go: switch to noembed build and bundle libs ``                                     |
| [`9789e1db`](https://github.com/NixOS/nixpkgs/commit/9789e1db1b6524539d1621c3bf15bb2bf80f33ae) | `` protoc-gen-twirp_swagger: drop ``                                                             |
| [`e5bfe7cb`](https://github.com/NixOS/nixpkgs/commit/e5bfe7cb9390f526a45d1152edcea1f1cc910ec6) | `` rofi-pass: drop ``                                                                            |
| [`6328591c`](https://github.com/NixOS/nixpkgs/commit/6328591c5664942ceeab96e9b41aeb897e852988) | `` nailgun: drop ``                                                                              |
| [`dd719868`](https://github.com/NixOS/nixpkgs/commit/dd7198688f2ad0cefb4df5488b9b6b319ff86a1b) | `` wasynth: drop ``                                                                              |
| [`d6200775`](https://github.com/NixOS/nixpkgs/commit/d6200775be464620cab1a8926538b7a6ffdaf3b5) | `` gshogi: drop ``                                                                               |
| [`fd4b4887`](https://github.com/NixOS/nixpkgs/commit/fd4b4887716721add70187da728a147c0f89f7b2) | `` renderizer: drop ``                                                                           |
| [`7c481187`](https://github.com/NixOS/nixpkgs/commit/7c4811879c25c6108d0128663c5c36dc5cdc88d1) | `` htb-toolkit: drop ``                                                                          |
| [`c859b8ce`](https://github.com/NixOS/nixpkgs/commit/c859b8ce683080f85240bbf850a7acd782a6f758) | `` chhoto-url: 7.5.0 -> 7.5.1 ``                                                                 |
| [`f2777250`](https://github.com/NixOS/nixpkgs/commit/f2777250997051cb2e641929c147e0709a6775c2) | `` netbird-dashboard: 2.91.1 -> 2.92.0 ``                                                        |
| [`2722d4b2`](https://github.com/NixOS/nixpkgs/commit/2722d4b287ff7c8f11725d0973bc553655f4828e) | `` python3Packages.coinmetrics-api-client: 2026.8.13.18 -> 2026.9.2.14 ``                        |
| [`c557a3e6`](https://github.com/NixOS/nixpkgs/commit/c557a3e68492b1b764928611e0ae84481152ba1e) | `` netbird: 0.77.1 -> 0.78.1 ``                                                                  |
| [`54aadac2`](https://github.com/NixOS/nixpkgs/commit/54aadac2885557c499c85888a69c2a5438b98da1) | `` python3Packages.stdlibs: 2026.2.26 -> 2026.9.3 ``                                             |
| [`2c9485e6`](https://github.com/NixOS/nixpkgs/commit/2c9485e683beacd5e4256ff473de7468439e8e10) | `` python3Packages.shacl2code: 1.2.0 -> 1.3.2 ``                                                 |
| [`c3172025`](https://github.com/NixOS/nixpkgs/commit/c31720256efae8e7bbff7cc2c8ce3a0dacb0143c) | `` vscode-extensions.anthropic.claude-code: 2.1.258 -> 2.1.260 ``                                |
| [`389e4012`](https://github.com/NixOS/nixpkgs/commit/389e40126b6a5383790fbf0d29b89ccbf3014c77) | `` claude-code: 2.1.258 -> 2.1.260 ``                                                            |
| [`5977edcc`](https://github.com/NixOS/nixpkgs/commit/5977edcc828872920d74caa1a9d47d7a9703e22a) | `` unordered_dense: 4.9.2 -> 4.11.0 ``                                                           |
| [`9f5967fc`](https://github.com/NixOS/nixpkgs/commit/9f5967fcfc11c7fd01d278f2617eacdb082506f1) | `` python3Packages.boto3-stubs: 1.43.87 -> 1.43.88 ``                                            |
| [`406ae9a1`](https://github.com/NixOS/nixpkgs/commit/406ae9a1086b13f540f12f6679e6c4cca9e144f5) | `` python3Packages.mypy-boto3-transfer: 1.43.0 -> 1.43.88 ``                                     |
| [`0b1bd0ed`](https://github.com/NixOS/nixpkgs/commit/0b1bd0ed20da2e2598d633a61e0d12da9e4cd1c4) | `` python3Packages.mypy-boto3-transcribe: 1.43.20 -> 1.43.88 ``                                  |
| [`89d83592`](https://github.com/NixOS/nixpkgs/commit/89d835921936e2bfc1bf34e600d79b3714477514) | `` python3Packages.mypy-boto3-stepfunctions: 1.43.7 -> 1.43.88 ``                                |
| [`b4fef052`](https://github.com/NixOS/nixpkgs/commit/b4fef0525ae013ffd68cd28ba25825b810404b31) | `` python3Packages.mypy-boto3-guardduty: 1.43.86 -> 1.43.88 ``                                   |
| [`b86edde8`](https://github.com/NixOS/nixpkgs/commit/b86edde8cbc52636517777e8d783a2a45cc7ca1d) | `` python3Packages.mypy-boto3-elbv2: 1.43.54 -> 1.43.88 ``                                       |
| [`ed032cf7`](https://github.com/NixOS/nixpkgs/commit/ed032cf73abaf2461ef7a058f0124c25e678a0ad) | `` python3Packages.mypy-boto3-eks: 1.43.80 -> 1.43.88 ``                                         |
| [`21525c17`](https://github.com/NixOS/nixpkgs/commit/21525c17e5f9010e93f0117865edada610c23b8a) | `` python3Packages.mypy-boto3-ecs: 1.43.83 -> 1.43.88 ``                                         |
| [`48b5c4f7`](https://github.com/NixOS/nixpkgs/commit/48b5c4f7f4e251507d66fa958f81ed78dd4d7a54) | `` python3Packages.mypy-boto3-drs: 1.43.73 -> 1.43.88 ``                                         |
| [`d283013f`](https://github.com/NixOS/nixpkgs/commit/d283013f7cc0a122fc53ad195088ff9644dd4283) | `` python3Packages.mypy-boto3-connect: 1.43.84 -> 1.43.88 ``                                     |
| [`df610665`](https://github.com/NixOS/nixpkgs/commit/df6106657c08c042ce63240f33dd31efbf578c5e) | `` python3Packages.publicsuffixlist: 1.0.2.20260902 -> 1.0.2.20260903 ``                         |
| [`6201287e`](https://github.com/NixOS/nixpkgs/commit/6201287e3e577f888394fce41bc316bf59285cda) | `` python3Packages.tencentcloud-sdk-python: 3.1.168 -> 3.1.169 ``                                |

*... and 2294 more commits (truncated)*