### PR TITLE
chore(flake/nixpkgs): `c043004d` -> `eaad0894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1789149629,
+        "narHash": "sha256-H6GwaZzZf+4npqv0tph94w9tZddSjFjmQrVsW0z78uk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "eaad089433ca2bb662274377d33df3d0e51ef28b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`0fcf3680`](https://github.com/NixOS/nixpkgs/commit/0fcf36803fcc836b476126432b3334b293538476) | `` tgrep: 1.0.7 -> 1.0.8 ``                                                                         |
| [`c56d3046`](https://github.com/NixOS/nixpkgs/commit/c56d3046395a0a811d5c092afd23efbb99fdaeb9) | `` python3Packages.mkdocs-build-plantuml-plugin: fix build ``                                       |
| [`6ef00dfd`](https://github.com/NixOS/nixpkgs/commit/6ef00dfd35e4aee68d39d16da9e6c6c2136f1b7f) | `` haskellPackages: regenerate package set based on current config ``                               |
| [`14d7d850`](https://github.com/NixOS/nixpkgs/commit/14d7d8501c04516724767150353335df8653cc75) | `` nixos/headplane: add server.proxy_auth option ``                                                 |
| [`a5fbff87`](https://github.com/NixOS/nixpkgs/commit/a5fbff87c02828ff35d5fd35b6559cf83e825075) | `` plexRaw: 1.43.3.10861-07dfddaeb -> 1.43.4.10903-e5521bd8c ``                                     |
| [`7445a96e`](https://github.com/NixOS/nixpkgs/commit/7445a96e799d89c2ec0c09bab737bddd61049fee) | `` par-lang: 0-unstable-2026-08-29 -> 0-unstable-2026-09-07 ``                                      |
| [`e59c449f`](https://github.com/NixOS/nixpkgs/commit/e59c449fab5d915d24448b5e4c9be2902022679a) | `` omp: init at 18.1.17 ``                                                                          |
| [`909f2fad`](https://github.com/NixOS/nixpkgs/commit/909f2fad88a8e2b679af9156d62be107f149d70c) | `` typos: 1.50.0 -> 1.50.1 ``                                                                       |
| [`243e7036`](https://github.com/NixOS/nixpkgs/commit/243e7036efac2924304ef415a163f1cb1eca6a37) | `` python3Packages.elevenlabs: 2.65.0 -> 2.67.0 ``                                                  |
| [`767cec3a`](https://github.com/NixOS/nixpkgs/commit/767cec3a03861cf346cabe8a7b2cb7c1eaf1bd26) | `` github-copilot-cli: 1.0.84-4 -> 1.0.83 ``                                                        |
| [`3cf7f287`](https://github.com/NixOS/nixpkgs/commit/3cf7f2876aa99c99ad85b73f54e855fd033511b1) | `` python3Packages.llama-index-graph-stores-neptune: migrate to finalAttrs ``                       |
| [`dfcafcf6`](https://github.com/NixOS/nixpkgs/commit/dfcafcf66b71d918be1f4324eeb2c912f3d3237f) | `` fatou: 0.18.0 -> 0.19.0 ``                                                                       |
| [`7e2a57ae`](https://github.com/NixOS/nixpkgs/commit/7e2a57ae3ef27209cf6611464fba97e6e0badec1) | `` python3Packages.llama-index-readers-s3: migrate to finalAttrs ``                                 |
| [`6203c3f2`](https://github.com/NixOS/nixpkgs/commit/6203c3f268bb295f7e9ecd1cc9eea0a51df16bd5) | `` mir_2_15: Fix compat with gtest 1.18 ``                                                          |
| [`2a687397`](https://github.com/NixOS/nixpkgs/commit/2a687397ce8b0ce99a9b8f0e59c7d8441df3b949) | `` python3Packages.zhong-hong-hvac: migrate to finalAttrs ``                                        |
| [`02e9e898`](https://github.com/NixOS/nixpkgs/commit/02e9e898740d1b62526248753b38eb7008d17054) | `` linphonePackages.linphone-desktop: fix crashes on GNOME ``                                       |
| [`eebba02d`](https://github.com/NixOS/nixpkgs/commit/eebba02d635926d244132258a96f001ed5a680de) | `` linphonePackages.linphone-desktop: remove double wrapping ``                                     |
| [`59ac360d`](https://github.com/NixOS/nixpkgs/commit/59ac360df659216a25fc773ac566d26400aaf3a9) | `` xaos: 4.3.7 -> 4.3.8 ``                                                                          |
| [`e56086cf`](https://github.com/NixOS/nixpkgs/commit/e56086cf98fce392670fddb5e3d2804f6002572d) | `` arity: 0.22.0 -> 0.23.0 ``                                                                       |
| [`63bbe6db`](https://github.com/NixOS/nixpkgs/commit/63bbe6db2fa985d3b0d5cd67c5cfcd1d24e21aac) | `` python3Packages.llama-index-vector-stores-google: migrate to finalAttrs ``                       |
| [`47325e5a`](https://github.com/NixOS/nixpkgs/commit/47325e5a66396d8b0a503edd33a11aa03d89fa85) | `` biome: 2.5.11 -> 2.5.13 ``                                                                       |
| [`8e5675cc`](https://github.com/NixOS/nixpkgs/commit/8e5675cc8ebd408311a940f537a03db9f36f3d54) | `` python3Packages.numdifftools: 0.11.0 -> 0.11.1 ``                                                |
| [`1efa56da`](https://github.com/NixOS/nixpkgs/commit/1efa56dabbdab890eba61c437658c71131a4f76c) | `` python3Packages.opower: 0.20.0 -> 0.21.0 ``                                                      |
| [`cac2abff`](https://github.com/NixOS/nixpkgs/commit/cac2abff44e3a7a3e688b7b19c5ab94922f146ef) | `` python3Packages.microsoft-kiota-serialization-text: 1.12.1 -> 1.12.2 ``                          |
| [`8bda7361`](https://github.com/NixOS/nixpkgs/commit/8bda7361de64486f640410e12c1f2d5319674c4e) | `` python3Packages.microsoft-kiota-serialization-multipart: 1.12.1 -> 1.12.2 ``                     |
| [`f8929e0a`](https://github.com/NixOS/nixpkgs/commit/f8929e0a426168332d41219cbea7486c5e163ba5) | `` python3Packages.microsoft-kiota-serialization-json: 1.12.1 -> 1.12.2 ``                          |
| [`d3a666e1`](https://github.com/NixOS/nixpkgs/commit/d3a666e18987f7f034e8b965c7caccec78b21016) | `` python3Packages.microsoft-kiota-serialization-form: 1.12.1 -> 1.12.2 ``                          |
| [`479aafb6`](https://github.com/NixOS/nixpkgs/commit/479aafb62c5adf4c354e39ce9668f786e52aa73f) | `` python3Packages.microsoft-kiota-http: 1.12.1 -> 1.12.2 ``                                        |
| [`1883ceeb`](https://github.com/NixOS/nixpkgs/commit/1883ceeb9a7f0a0b8596fc1eeb86b846713d868e) | `` python3Packages.microsoft-kiota-authentication-azure: 1.12.1 -> 1.12.2 ``                        |
| [`32f0e3d9`](https://github.com/NixOS/nixpkgs/commit/32f0e3d949e956d8f7cb006e0f147262895c0798) | `` python3Packages.microsoft-kiota-abstractions: 1.12.1 -> 1.12.2 ``                                |
| [`a2e77aba`](https://github.com/NixOS/nixpkgs/commit/a2e77aba85cd448d19ee1f4202194b7f7e21c424) | `` tuxbox: 3.3.0 -> 3.4.0 ``                                                                        |
| [`dcbded4c`](https://github.com/NixOS/nixpkgs/commit/dcbded4c202ecd36e3025db501c112b896d33a25) | `` httpx: 1.11.0 -> 1.12.0 ``                                                                       |
| [`a0fa2d3f`](https://github.com/NixOS/nixpkgs/commit/a0fa2d3fa43b6a36d140edf399801cb87d5e1bc9) | `` diskwatch: 0.5.1 -> 0.5.2 ``                                                                     |
| [`b50fe310`](https://github.com/NixOS/nixpkgs/commit/b50fe310e907adb7fbfacabb98f1804db67a6651) | `` rtorrent: 0.16.20 -> 0.16.22 ``                                                                  |
| [`bb207967`](https://github.com/NixOS/nixpkgs/commit/bb2079672a0562dc3e164bee959e4781d3ec945f) | `` python3Packages.trimesh: 5.0.0 -> 5.1.0 ``                                                       |
| [`6b6086ec`](https://github.com/NixOS/nixpkgs/commit/6b6086ec1550989a283a23ecada0d639b78cf587) | `` python3Packages.llama-index-graph-stores-neo4j: 0.7.0 -> 0.8.0 ``                                |
| [`91d23d79`](https://github.com/NixOS/nixpkgs/commit/91d23d7925f410ff129e283fd51be64c8fa644c9) | `` renderdoc: 1.45 -> 1.46 ``                                                                       |
| [`7ba387df`](https://github.com/NixOS/nixpkgs/commit/7ba387df069e0730a0be43145ccceeae10c105a8) | `` linux_6_18: 6.18.50 -> 6.18.51 ``                                                                |
| [`a856a94b`](https://github.com/NixOS/nixpkgs/commit/a856a94b2cbd19392b8f34b47a2bcc56c1b7386a) | `` linux_7_2: 7.2.4 -> 7.2.5 ``                                                                     |
| [`ae77bf3f`](https://github.com/NixOS/nixpkgs/commit/ae77bf3fc779b1779bf5ffc749f2f8048b4bc853) | `` python3Packages.llama-index-vector-stores-google: 0.5.0 -> 0.6.0 ``                              |
| [`bf546038`](https://github.com/NixOS/nixpkgs/commit/bf546038f89a0116b479f629f160422b9af06a06) | `` consul: 2.0.3 -> 2.0.4 ``                                                                        |
| [`2d109167`](https://github.com/NixOS/nixpkgs/commit/2d10916756bb6b4091a98917f1b35538557b7afe) | `` terraform-providers.temporalio_temporalcloud: 1.7.0 -> 1.9.0 ``                                  |
| [`7deec481`](https://github.com/NixOS/nixpkgs/commit/7deec481cc3e9c5593dec7c092a8daef5ba61ea6) | `` sdl3-shadercross: 0-unstable-2026-06-26 -> 0-unstable-2026-09-03 ``                              |
| [`b89fda18`](https://github.com/NixOS/nixpkgs/commit/b89fda182c9eb6972aa618436ed2f824b03d40b5) | `` python3Packages.rns: 1.5.2 -> 1.5.3 ``                                                           |
| [`6eb20c07`](https://github.com/NixOS/nixpkgs/commit/6eb20c0761e9b28e316564e0ca89308772389246) | `` python3Packages.nomadnet: 1.4.1 -> 1.4.2 ``                                                      |
| [`d5c28473`](https://github.com/NixOS/nixpkgs/commit/d5c2847358df6c1d853e6d940401a54a59cda5b1) | `` python3Packages.bambi: 0.20.0 -> 0.21.0 ``                                                       |
| [`ca690714`](https://github.com/NixOS/nixpkgs/commit/ca6907148c1025caffb14d5c65769d81fc14f757) | `` nixos/tests/vlm-screenshot-question: more precise instructions to fix test ``                    |
| [`c5d491c0`](https://github.com/NixOS/nixpkgs/commit/c5d491c03b7ac6d726afe80f14b4f6416c6fd73d) | `` nixos/tests/vlm-screenshot-question: fix llama-cpp binary path ``                                |
| [`e6bb426e`](https://github.com/NixOS/nixpkgs/commit/e6bb426ee84c19353a73d37a042dd178c8602b3d) | `` cloudcompare: modernize package ``                                                               |
| [`e697abd3`](https://github.com/NixOS/nixpkgs/commit/e697abd34cb66d7ce4ef2cea78b4391d70c49edb) | `` cloudcompare: 2.13.2 -> 2.13.2-unstable-2026-08-21 ``                                            |
| [`e096e18a`](https://github.com/NixOS/nixpkgs/commit/e096e18aa6878c5cdca972c282c5d1e0b13f56db) | `` gplates: 2.5.0-dev3 -> 2.6.0-unstable-2026-08-18 ``                                              |
| [`25f39041`](https://github.com/NixOS/nixpkgs/commit/25f390417269198391e3df722c5a6df3ae61b35b) | `` sgt-puzzles: update to 20260911.428913c ``                                                       |
| [`8440917b`](https://github.com/NixOS/nixpkgs/commit/8440917b42db5be478de571e10525f77039e6115) | `` rerun: 0.37.1 -> 0.37.2 ``                                                                       |
| [`9760b91b`](https://github.com/NixOS/nixpkgs/commit/9760b91b7a7423f0028f37fd3d495b5e30511b48) | `` python3Packages.boto3-stubs: 1.43.91 -> 1.43.92 ``                                               |
| [`aa2a309c`](https://github.com/NixOS/nixpkgs/commit/aa2a309cf1b87b69da14600e629a14f60b59afde) | `` python3Packages.mypy-boto3-sagemaker: 1.43.90 -> 1.43.92 ``                                      |
| [`9777a45a`](https://github.com/NixOS/nixpkgs/commit/9777a45aba97a2f96458f350fa31018b9125cf0e) | `` python3Packages.mypy-boto3-outposts: 1.43.74 -> 1.43.92 ``                                       |
| [`a6e3bbba`](https://github.com/NixOS/nixpkgs/commit/a6e3bbba5915b3fd4ada29cf253e75da77e50736) | `` python3Packages.mypy-boto3-ec2: 1.43.91 -> 1.43.92 ``                                            |
| [`70ce253f`](https://github.com/NixOS/nixpkgs/commit/70ce253fb8a3438bdd4d48d6d646541ef3d8838f) | `` kde-modernclock: init at 0.2.0-unstable-2024-03-07 ``                                            |
| [`bb560a68`](https://github.com/NixOS/nixpkgs/commit/bb560a68e172ad2c4c7f1b089ab532708669f30d) | `` terraform-providers.sysdiglabs_sysdig: 3.9.1 -> 3.9.2 ``                                         |
| [`85da7e3e`](https://github.com/NixOS/nixpkgs/commit/85da7e3e1dcb99c85399c2d934cea4671eb7bed4) | `` nerva: 1.69.6 -> 1.69.7 ``                                                                       |
| [`8e1ad8f4`](https://github.com/NixOS/nixpkgs/commit/8e1ad8f469aff35ec3e457f04f67c97051e760dc) | `` linyaps: 1.14.0 -> 1.14.1 ``                                                                     |
| [`728b2cb7`](https://github.com/NixOS/nixpkgs/commit/728b2cb753c47b0069e8b84e95f5abe045ec8d7c) | `` python3Packages.frigidaire: modernize ``                                                         |
| [`3bb6b4f1`](https://github.com/NixOS/nixpkgs/commit/3bb6b4f110b75229f94a47ef9d977eb37d047d59) | `` python3Packages.frigidaire: enable tests ``                                                      |
| [`56da4251`](https://github.com/NixOS/nixpkgs/commit/56da4251ac8ea37425b6b6e32aed85b1d397e4b7) | `` python3Packages.frigidaire: 0.18.53 -> 1.0.0 ``                                                  |
| [`50fa2143`](https://github.com/NixOS/nixpkgs/commit/50fa21431f4153d517046006da87b270f245dc27) | `` python3Packages.tencentcloud-sdk-python: 3.1.173 -> 3.1.174 ``                                   |
| [`ca85e759`](https://github.com/NixOS/nixpkgs/commit/ca85e759e54bd539d37ddac5e33fca4483314c29) | `` python3Packages.iamdata: 0.1.202609101 -> 0.1.202609111 ``                                       |
| [`74c2f8cd`](https://github.com/NixOS/nixpkgs/commit/74c2f8cdd77e41ca74100b4d380c83e5020cd298) | `` rocqPackages.equations: 1.3.2+9.2 -> 1.3.2+9.3 ``                                                |
| [`8aea6d83`](https://github.com/NixOS/nixpkgs/commit/8aea6d83488d1b53151703aad2f6d4f8cca2ebf0) | `` gradle-completion: 9.6.1 -> 9.7.1 ``                                                             |
| [`643beca3`](https://github.com/NixOS/nixpkgs/commit/643beca34784abb5ea59fa49b1b821043d2725af) | `` simpleini: 4.26 -> 4.27 ``                                                                       |
| [`1f2ce128`](https://github.com/NixOS/nixpkgs/commit/1f2ce128e45dc806fbce862cb1cd2223b95f2e32) | `` kanidm_1_11: 1.11.1 -> 1.11.2 ``                                                                 |
| [`a30a8180`](https://github.com/NixOS/nixpkgs/commit/a30a81800e04b350dd6ce1900873e5405aab2b5e) | `` coder: 2.35.6 -> 2.36.5 ``                                                                       |
| [`5f2a4f50`](https://github.com/NixOS/nixpkgs/commit/5f2a4f5011c63a7948a37ae9c70fcd0a6a2112e9) | `` gitlab-elasticsearch-indexer: 5.14.7 -> 5.14.13 ``                                               |
| [`363a1390`](https://github.com/NixOS/nixpkgs/commit/363a1390808197f6ed0ed41a04f1dd9babeaa1fc) | `` gitlab: 19.3.1 -> 19.3.2 ``                                                                      |
| [`161a9ae7`](https://github.com/NixOS/nixpkgs/commit/161a9ae7b3a12c1350ff27f7073726763df5b4a9) | `` valeStyles.redhat: 677 -> 678 ``                                                                 |
| [`f58689df`](https://github.com/NixOS/nixpkgs/commit/f58689df4aa4b47754c859f1061c65ab67ff0fce) | `` dotnetbuildhelpers: add license ``                                                               |
| [`f0a7d242`](https://github.com/NixOS/nixpkgs/commit/f0a7d2424f8cc07ca156652e608f545580b918e8) | `` terraform-providers.hashicorp_azurerm: 5.3.0 -> 5.5.0 ``                                         |
| [`148432ea`](https://github.com/NixOS/nixpkgs/commit/148432eac0557a0448d200f9724071e8ad12fc69) | `` python3Packages.databricks-sdk: 0.133.0 -> 0.138.0 ``                                            |
| [`ae9cc143`](https://github.com/NixOS/nixpkgs/commit/ae9cc143260b50673936416a380bc4b576d94f40) | `` tgrep: 1.0.5 -> 1.0.7 ``                                                                         |
| [`58c7c90d`](https://github.com/NixOS/nixpkgs/commit/58c7c90d6920885470c73b76b5df627672efba07) | `` lomiri.lomiri-content-hub: fix by -Wno-error=FOO ``                                              |
| [`b4917725`](https://github.com/NixOS/nixpkgs/commit/b4917725236334e935aa31206fa846ae660951cc) | `` wlcs: fix by another -Wno-error=FOO ``                                                           |
| [`904e2cae`](https://github.com/NixOS/nixpkgs/commit/904e2cae9646d4a6930e1aefc99d42c72d55a121) | `` bant: 0.3.5 -> 0.3.6 ``                                                                          |
| [`79911202`](https://github.com/NixOS/nixpkgs/commit/79911202e2810dad64a806fcfa65142e666a47cb) | `` nixos-container: add license ``                                                                  |
| [`94eb12e8`](https://github.com/NixOS/nixpkgs/commit/94eb12e802b91e63363cb41bf66d1a5ce04c6b15) | `` home-assistant-custom-components.ha_mcp_tools: add voluptuous-openapi ``                         |
| [`22f1174d`](https://github.com/NixOS/nixpkgs/commit/22f1174d310d10c0ecb1a9d7e00159be64646c1e) | `` python3Packages.ha-mcp: 8.4.0 -> 8.4.3 ``                                                        |
| [`55d3d363`](https://github.com/NixOS/nixpkgs/commit/55d3d36377022038f41c6a2f2a373e752dee3c09) | `` thunderbird-153-unwrapped: 153.1.1esr -> 153.2.0esr ``                                           |
| [`cc3d66c3`](https://github.com/NixOS/nixpkgs/commit/cc3d66c3f4cb9d506eacf542082b017f4c798775) | `` python3Packages.aioslimproto: 3.1.9 -> 3.2.0 ``                                                  |
| [`e81ce467`](https://github.com/NixOS/nixpkgs/commit/e81ce467062829fdf4547bafb0b361d86509605a) | `` python3Packages.zhong-hong-hvac: 1.0.19 -> 1.0.21 ``                                             |
| [`3865c812`](https://github.com/NixOS/nixpkgs/commit/3865c812326dd650dd356bb31b1584f07ef3a73d) | `` mojoshader: 0-unstable-2026-04-28 -> 0-unstable-2026-09-03 ``                                    |
| [`e13c7b17`](https://github.com/NixOS/nixpkgs/commit/e13c7b1743a45611345c97b53aefd7baa0387729) | `` vips_8_17: drop ``                                                                               |
| [`c358f8df`](https://github.com/NixOS/nixpkgs/commit/c358f8dfc87adf9bba940a5b65ce7de9a6273784) | `` immich: add diogotcorreia to maintainers ``                                                      |
| [`7d7b9bb8`](https://github.com/NixOS/nixpkgs/commit/7d7b9bb8a4d62722a2860afd44ee059ee42fbff8) | `` immich: 3.1.0 -> 3.2.0 ``                                                                        |
| [`4cba04bf`](https://github.com/NixOS/nixpkgs/commit/4cba04bf724a5a771360981f668e5016644959a5) | `` python3Packages.iocx: 0.7.6.1 -> 0.7.6.2 ``                                                      |
| [`b46aa8d2`](https://github.com/NixOS/nixpkgs/commit/b46aa8d28dab4d9ecd1b6bf63b36e027820d59d1) | `` wrapWithXFileSearchPathHook: add license ``                                                      |
| [`0b3bc660`](https://github.com/NixOS/nixpkgs/commit/0b3bc660e294157cea31f636545ec301a492c946) | `` opentyrian: add license ``                                                                       |
| [`f59e8f83`](https://github.com/NixOS/nixpkgs/commit/f59e8f8387bbfaac1d30f58663e55b48053a5dad) | `` vikunja-desktop: 2.3.0 -> 2.6.0 ``                                                               |
| [`ca585e9b`](https://github.com/NixOS/nixpkgs/commit/ca585e9b4b7d652f8b8730dfacd49287a8c19dbe) | `` capslock: add sotormd as maintainer ``                                                           |
| [`b74a82da`](https://github.com/NixOS/nixpkgs/commit/b74a82da3950d4b89b5af5df21a0d2e3da43dc3d) | `` niks3: 1.10.1 -> 1.11.0 ``                                                                       |
| [`2387374f`](https://github.com/NixOS/nixpkgs/commit/2387374facf4aa4377e0ac6f0e6d71a2a7e207a2) | `` ictree: add license ``                                                                           |
| [`a29f5a95`](https://github.com/NixOS/nixpkgs/commit/a29f5a9511a2a38fbee4f9c000a33b191f3ead64) | `` icon-conv-tools: add license ``                                                                  |
| [`5adced20`](https://github.com/NixOS/nixpkgs/commit/5adced20ffd4b9659b415c9ad19374f450aee2ae) | `` git2cl: add license ``                                                                           |
| [`c1c0a2d4`](https://github.com/NixOS/nixpkgs/commit/c1c0a2d4c5fb9d5594601ec9ac49a50b37222bc1) | `` grin: add license ``                                                                             |
| [`89e905fa`](https://github.com/NixOS/nixpkgs/commit/89e905fae033be0bb01666d2004c4885a8e92f2b) | `` jjui: 0.10.9 -> 0.10.10 ``                                                                       |
| [`ff126ad0`](https://github.com/NixOS/nixpkgs/commit/ff126ad0b966fd625d742edb1c0a5c9d6eb292c4) | `` fake-nss: add license ``                                                                         |
| [`4b87f6a6`](https://github.com/NixOS/nixpkgs/commit/4b87f6a6de32ad2104851b672353cc7295e207e1) | `` tetex: add license ``                                                                            |
| [`28235d10`](https://github.com/NixOS/nixpkgs/commit/28235d10fbd3022241b0697d7d5b3647fadbadf2) | `` turingplus: add bootstrap test to `passthru.tests` ``                                            |
| [`c789472d`](https://github.com/NixOS/nixpkgs/commit/c789472d9edc3b7bda4227918abdf6d95d7bdaad) | `` popa3d: add license ``                                                                           |
| [`3b4a8d54`](https://github.com/NixOS/nixpkgs/commit/3b4a8d549ed684a7ff5ae3ff9f8fc185b9ad3c9a) | `` nix-info: add license ``                                                                         |
| [`fe6e3cab`](https://github.com/NixOS/nixpkgs/commit/fe6e3cab67c1436f8332cd0ed85d34f1c026f2a6) | `` mssql-jdbc: add license ``                                                                       |
| [`fe5e4482`](https://github.com/NixOS/nixpkgs/commit/fe5e4482ccab24c68b3c5b3f10f2b212486cd4bb) | `` system-sendmail: add license ``                                                                  |
| [`211a4f21`](https://github.com/NixOS/nixpkgs/commit/211a4f21db048b85a074e66775650501c01b80e4) | `` topgrade: 17.9.0 -> 17.10.0 ``                                                                   |
| [`989fb6e5`](https://github.com/NixOS/nixpkgs/commit/989fb6e5f73f793fe6aab6ae90e1a2fa219de002) | `` xorg_sys_opengl: add license ``                                                                  |
| [`53b5283c`](https://github.com/NixOS/nixpkgs/commit/53b5283c88d569f2b4ae894db258d7ab855f943e) | `` unrar: 7.2.7 -> 7.3.1 ``                                                                         |
| [`7bf0ef04`](https://github.com/NixOS/nixpkgs/commit/7bf0ef0444bfa58e3e7fb381a3f3cfa59732cdf0) | `` python3Packages.homelink-integration-api: 0.0.5 -> 0.1.0 ``                                      |
| [`c8c4fb38`](https://github.com/NixOS/nixpkgs/commit/c8c4fb38b048668b7a4bca48715f5c4f502beeaf) | `` nixfmt: 1.4.0 → 1.5.0 ``                                                                         |
| [`bbb536ca`](https://github.com/NixOS/nixpkgs/commit/bbb536ca711bcd301fb7150e624ee0e5c1670bcf) | `` python3Packages.fressnapftracker: 0.3.0 -> 0.3.1 ``                                              |
| [`adffb7ff`](https://github.com/NixOS/nixpkgs/commit/adffb7ff05b4fdadd0d917c1207df4e4749bc14a) | `` perf-linux: add license ``                                                                       |
| [`0f7aad6c`](https://github.com/NixOS/nixpkgs/commit/0f7aad6cc1c16af6c133ea64eb00fda94727207c) | `` python3Packages.lacuscore: 1.25.2 -> 1.26.1 ``                                                   |
| [`6a133b26`](https://github.com/NixOS/nixpkgs/commit/6a133b2655c3d2e0a347d3f61f09a23e18c265a7) | `` oath-toolkit: add license ``                                                                     |
| [`d6989e28`](https://github.com/NixOS/nixpkgs/commit/d6989e28bda92d287b57daf5969dbcc468fdf1f2) | `` syswatch: 0.10.0 -> 0.11.0 ``                                                                    |
| [`4f895bf6`](https://github.com/NixOS/nixpkgs/commit/4f895bf6c422539ab39d590c48622f1b3a7236f5) | `` gtksourceviewmm4: drop ``                                                                        |
| [`ec9ee961`](https://github.com/NixOS/nixpkgs/commit/ec9ee96131331cad845b719f7f314948581a4f3f) | `` pyprland: 3.4.3 -> 3.4.4 ``                                                                      |
| [`00042de6`](https://github.com/NixOS/nixpkgs/commit/00042de6de77e97c557a7f1bed2df1ceef199286) | `` nusmv: add license ``                                                                            |
| [`1e7325d2`](https://github.com/NixOS/nixpkgs/commit/1e7325d214598dbf173e6ca50e6fdf9a2ca599d7) | `` hello-cpp: add license ``                                                                        |
| [`3e4acacb`](https://github.com/NixOS/nixpkgs/commit/3e4acacb9ae9241ddf9167f3fcab0e66c2b79f5e) | `` libcec: 7.1.1 -> 8.1.7 ``                                                                        |
| [`6c74a4bb`](https://github.com/NixOS/nixpkgs/commit/6c74a4bbfb97beb8dad2e3c35cd8588b8a77cb57) | `` waylogout: unstable-2023-06-09 -> 0.3 ``                                                         |
| [`13be083f`](https://github.com/NixOS/nixpkgs/commit/13be083f8f5152d9ef520c43fde9e267caa57c36) | `` nixos/k3b: remove redundant 'manual step' docs ``                                                |
| [`1ddf6a84`](https://github.com/NixOS/nixpkgs/commit/1ddf6a84ebf013a2a3d42c389a7b4c6befc3ee6e) | `` kdePackages.k3b: add /run/wrappers/bin to the PATH ``                                            |
| [`fa1c91e1`](https://github.com/NixOS/nixpkgs/commit/fa1c91e136852ed785dc0719b6227a10f7b3a785) | `` nixpkgs-lint: add license ``                                                                     |
| [`515c8226`](https://github.com/NixOS/nixpkgs/commit/515c8226864a441d72eccd87a7177a69add431e8) | `` nix-generate-from-cpan-3: add license ``                                                         |
| [`059d8dda`](https://github.com/NixOS/nixpkgs/commit/059d8dda4cadb5574dc73da15257d3e28a6a91e9) | `` nixpkgs-manual: add license ``                                                                   |
| [`c641fb64`](https://github.com/NixOS/nixpkgs/commit/c641fb64b7499da807a1d75f9bd55ce435f6a27a) | `` darwin.linux-builder{-x86_64,-vz}: adopt ``                                                      |
| [`b85d9864`](https://github.com/NixOS/nixpkgs/commit/b85d98644b4211b0c00ee189ed11e8871468156b) | `` python3Packages.sqlmap: 1.10.8 -> 1.10.9 ``                                                      |
| [`e0a59dcf`](https://github.com/NixOS/nixpkgs/commit/e0a59dcfa45530938fe04fb84c7e27ad52213bdc) | `` bakoma_ttf: use installFonts ``                                                                  |
| [`1f411e85`](https://github.com/NixOS/nixpkgs/commit/1f411e853bc9046b1906cd54ad4a0671c924317b) | `` home-assistant-custom-components.homematicip_local: 2.11.0 -> 2.11.1 ``                          |
| [`4139fa64`](https://github.com/NixOS/nixpkgs/commit/4139fa645057e21f67b9ec90625669f625d25e00) | `` python3Packages.openccu-loom-client: 2026.9.3 -> 2026.9.4 ``                                     |
| [`2420064b`](https://github.com/NixOS/nixpkgs/commit/2420064b84ea289b504c635f6d5facb6b8429d92) | `` python3Packages.openccu-data: 2026.7.2 -> 2026.9.0 ``                                            |
| [`013bf83f`](https://github.com/NixOS/nixpkgs/commit/013bf83f49bb5b47634f99a9b756d65a47ad1a95) | `` python3Packages.aiohomematic: 2026.9.1 -> 2026.9.2 ``                                            |
| [`714ff848`](https://github.com/NixOS/nixpkgs/commit/714ff848e80bdc59548fe0a7edf27ca89dd72dc2) | `` renovate: 44.52.0 -> 44.79.2 ``                                                                  |
| [`f3848651`](https://github.com/NixOS/nixpkgs/commit/f384865105f34814d06be61006fe85e7120e3653) | `` intel-llvm: fix eval after intel-compute-runtime drivers output removal ``                       |
| [`aac69eda`](https://github.com/NixOS/nixpkgs/commit/aac69eda392eaa297496574735c0e5ec42750d1e) | `` python3Packages.ansi2html: 1.9.3 -> 1.9.5 ``                                                     |
| [`39b8a8a7`](https://github.com/NixOS/nixpkgs/commit/39b8a8a72085343a6e5d5e047fff0be46a73ac5e) | `` gh-gonest: 0-unstable-2025-12-17 -> 0-unstable-2026-08-31 ``                                     |
| [`2d72ab3a`](https://github.com/NixOS/nixpkgs/commit/2d72ab3ad31cf050b83b824ed6edf0d47f7e7317) | `` nixos/coder: add url to Coder configuration reference ``                                         |
| [`8c0f40d1`](https://github.com/NixOS/nixpkgs/commit/8c0f40d19ed72040bd10e8ca071d1c29a320c553) | `` microcad: add aarch64-darwin support ``                                                          |
| [`dbb3ac26`](https://github.com/NixOS/nixpkgs/commit/dbb3ac2612ecaa5a89b17a9e02414c5dcb8f7a71) | `` databricks-cli: enable __structuredAttrs ``                                                      |
| [`ae275b7d`](https://github.com/NixOS/nixpkgs/commit/ae275b7de03be93b4a4377aaae7f55b99c59a0dc) | `` trunk-io: modernize slightly ``                                                                  |
| [`e2384126`](https://github.com/NixOS/nixpkgs/commit/e2384126739c5eb0d1dfab2554ee8277433754d7) | `` autobrr: drop unused typescript ``                                                               |
| [`fdb29ef8`](https://github.com/NixOS/nixpkgs/commit/fdb29ef8d40f136484d26d2b42a05801d6c3b25a) | `` nix-store-veritysetup-generator: 1.0.1 -> 1.1.0 ``                                               |
| [`10dec0a2`](https://github.com/NixOS/nixpkgs/commit/10dec0a250a26030f4e49b36fe5162de93daffdb) | `` libhwy: fix CMake config ``                                                                      |
| [`9a923633`](https://github.com/NixOS/nixpkgs/commit/9a9236336fea7c2118cb230a046d7b320a3ebf0c) | `` odhcp6c: 0-unstable-2026-01-25 -> 0-unstable-2026-06-27, set main program and structuredAttrs `` |
| [`7abcd0bf`](https://github.com/NixOS/nixpkgs/commit/7abcd0bf4325baaf83c968c44272633f3e08d973) | `` python3Packages.oelint-data: 1.5.18 -> 1.5.19 ``                                                 |
| [`9ce90867`](https://github.com/NixOS/nixpkgs/commit/9ce908677e13197cc139db64abd0981d16f23dbd) | `` doc: recommend channel tarball in Darwin flake example ``                                        |
| [`1a4221bb`](https://github.com/NixOS/nixpkgs/commit/1a4221bb7d0974ced58e332bbf35149fbac6f222) | `` vscode-extensions.banacorn.agda-mode: 0.10.1 -> 0.10.2 ``                                        |
| [`96d88391`](https://github.com/NixOS/nixpkgs/commit/96d88391315de1ac42630cc859ceb297b7bb418c) | `` paseo-relay: init at 0-unstable-2026-08-22 ``                                                    |
| [`611156ba`](https://github.com/NixOS/nixpkgs/commit/611156baf1fea50257bb56f3ad442fe06f37dd38) | `` paseo: init at 0.8.0 ``                                                                          |
| [`9cba6504`](https://github.com/NixOS/nixpkgs/commit/9cba65040098b4a1d9c64299463321b9dd8722c6) | `` libretro.beetle-vb: 0-unstable-2026-07-29 -> 0-unstable-2026-08-23 ``                            |
| [`74771ee6`](https://github.com/NixOS/nixpkgs/commit/74771ee6b3539540fd1fba4d9e6cdca74986bd19) | `` python3Packages.scikit-posthocs: 0.16.1 -> 0.17.0 ``                                             |
| [`ae39b4f5`](https://github.com/NixOS/nixpkgs/commit/ae39b4f5de0e82abed38956c8550ef73092f5871) | `` sparkle: 1.26.7 -> 1.26.8 ``                                                                     |
| [`cea5b7e5`](https://github.com/NixOS/nixpkgs/commit/cea5b7e52d5479a8757588523b12296aa4105d5c) | `` openapi-python-client: 0.29.0 -> 0.29.1 ``                                                       |
| [`ce7ad4f5`](https://github.com/NixOS/nixpkgs/commit/ce7ad4f54ab9b4c7b5829a319b92636b71a39a2f) | `` python3Packages.torchrl: use git tag for 0.14.0 release ``                                       |
| [`80dbcc8c`](https://github.com/NixOS/nixpkgs/commit/80dbcc8cd2ba7d0f0ec864898961600ccd2d1d28) | `` yarn-berry: patch `got` dependency ``                                                            |
| [`aa0c4f77`](https://github.com/NixOS/nixpkgs/commit/aa0c4f77a9dcfdcb09c4f4fc85f6d5dab181f199) | `` runpodctl: 2.12.0 -> 2.13.0 ``                                                                   |
| [`3999fbb0`](https://github.com/NixOS/nixpkgs/commit/3999fbb06b46f76f863eb7be38c7ee0c0d796880) | `` noctalia-greeter: 1.3.1 -> 1.5.0 ``                                                              |
| [`65bddf5f`](https://github.com/NixOS/nixpkgs/commit/65bddf5fd3531323e1367fc52d129c142e2f6fe7) | `` noctalia: 5.0.1 -> 5.1.0 ``                                                                      |
| [`584080e2`](https://github.com/NixOS/nixpkgs/commit/584080e2305af8ae8d3e93d65b6ea93289ae30c9) | `` fastpotify: init at 0.7.1 ``                                                                     |
| [`cb4e763d`](https://github.com/NixOS/nixpkgs/commit/cb4e763d9771b3ef8ba2db6a36443e88485af20e) | `` maintainers: add DmitrySkibitsky ``                                                              |
| [`1429cfba`](https://github.com/NixOS/nixpkgs/commit/1429cfba732d8dcd6f0aff53d4527d54e612307c) | `` python3Packages.tensordict: 0.14.1 -> 0.14.2 ``                                                  |
| [`3779f7e2`](https://github.com/NixOS/nixpkgs/commit/3779f7e2766c17b515c5e1d11ceeff3b8816df94) | `` loguru: 2.1.0 -> 2.2.0 ``                                                                        |
| [`6547164b`](https://github.com/NixOS/nixpkgs/commit/6547164ba88d31d24277f155c6aeeeeb6d258fcc) | `` home-assistant-custom-components.openai-tts: init at 3.9.1 ``                                    |
| [`a62d46f0`](https://github.com/NixOS/nixpkgs/commit/a62d46f0aef8f49c7ef8f8cc086848e189b11c5c) | `` yoinks: init at 0.3.1 ``                                                                         |
| [`b8967eee`](https://github.com/NixOS/nixpkgs/commit/b8967eee6adf781745b9daf2c3a7d76bba29e3ef) | `` swayosd: 0.3.1 -> 0.3.2 ``                                                                       |
| [`f550450b`](https://github.com/NixOS/nixpkgs/commit/f550450b63f92635905d94670df65f9860a6addc) | `` lprobe: 0.2.0 -> 0.2.1 ``                                                                        |
| [`65ddfb8b`](https://github.com/NixOS/nixpkgs/commit/65ddfb8b58075cab62cc61cca3c72db9849f6a5c) | `` go-swagger: 0.36.5 -> 0.36.6 ``                                                                  |
| [`a0ef093c`](https://github.com/NixOS/nixpkgs/commit/a0ef093c58fe79ee701a7d2682b12f16d73fdc75) | `` tart: 2.36.0 -> 2.37.0 ``                                                                        |
| [`e3fa00d1`](https://github.com/NixOS/nixpkgs/commit/e3fa00d1f4e31f4cb0e9b4f01a7a27689373fb73) | `` forgejo: 16.0.3 -> 16.0.4 ``                                                                     |
| [`d8729a9b`](https://github.com/NixOS/nixpkgs/commit/d8729a9b7663915d8e4c7e434acc4717da70fbb7) | `` forgejo-lts: 15.0.7 -> 15.0.8 ``                                                                 |
| [`8cef61c4`](https://github.com/NixOS/nixpkgs/commit/8cef61c44ebced63c6be4311b866d929e9fd29f7) | `` tea-dash: init at 0.3.7 ``                                                                       |
| [`f632391d`](https://github.com/NixOS/nixpkgs/commit/f632391d1cc6bf8d98dc0f306b2780d6560c1082) | `` linux-firmware: 20260810 -> 20260910 ``                                                          |
| [`6dbb0a9d`](https://github.com/NixOS/nixpkgs/commit/6dbb0a9d1de13424e4050518e16cd563d8f8da69) | `` kdePackages: Gear 26.08.0 -> 26.08.1 ``                                                          |
| [`00c7167d`](https://github.com/NixOS/nixpkgs/commit/00c7167db91fdc8cf93eae15f174ce93c6b7c62b) | `` cosmic-ext-applet-workspace-icons: init at 1.2.0 ``                                              |
| [`90cdc4ad`](https://github.com/NixOS/nixpkgs/commit/90cdc4ad06fefc622be0b13fd31e2fbf771b17a9) | `` python3Packages.gluonts: 0.16.3 -> 0.17.0 ``                                                     |
| [`59458634`](https://github.com/NixOS/nixpkgs/commit/5945863470ddcd449872fa45f972ad4106ff1a17) | `` credsweeper: 1.18.2 -> 1.18.3 ``                                                                 |
| [`8f82a1db`](https://github.com/NixOS/nixpkgs/commit/8f82a1db7bbb1f9e82327a869dc371bc74471385) | `` budget-tracker-tui: 1.4.2 -> 1.6.0 ``                                                            |
| [`1219ed42`](https://github.com/NixOS/nixpkgs/commit/1219ed420d5fde32dcc9c6fea3650bf7f574629e) | `` python3Packages.pyg-lib: 0.8.0 -> 0.9.0 ``                                                       |
| [`4d8ed510`](https://github.com/NixOS/nixpkgs/commit/4d8ed510d517ebb960168226de7c3e6379a33b51) | `` xgboost: remove `cudatoolkit` in favor of explicit packages ``                                   |
| [`fabd2f88`](https://github.com/NixOS/nixpkgs/commit/fabd2f886ff4b06e634b9773dac714cdb5ace9f7) | `` xgboost: cleanup cmakeFlags by using lib.cmake* ``                                               |
| [`d411ab85`](https://github.com/NixOS/nixpkgs/commit/d411ab855c565d0d166edf177b558bddcc3d7cd9) | `` xgboost: finalAttrs, enable __structuredAttrs, strictDeps ``                                     |
| [`e1bd7eeb`](https://github.com/NixOS/nixpkgs/commit/e1bd7eeb5bbadf9ac8c7a1342447370cb7788130) | `` openspec: 1.10.0 -> 1.13.0 ``                                                                    |
| [`07e99535`](https://github.com/NixOS/nixpkgs/commit/07e99535c45d7b4bcbb8800e00fd4684a35b2c6c) | `` resonarium: 0.1.0 -> 0.1.1 ``                                                                    |
| [`6bff1eb8`](https://github.com/NixOS/nixpkgs/commit/6bff1eb8e4aee11f89da75ed0338f928ff616b60) | `` python3Packages.mhcgnomes: 3.39.0 -> 3.64.2 ``                                                   |
| [`e12d0ae2`](https://github.com/NixOS/nixpkgs/commit/e12d0ae272302c3e8f861d93ddcb73d2fe3992d0) | `` dms-greeter: 1.6.0 -> 1.6.1 ``                                                                   |
| [`fb4effc6`](https://github.com/NixOS/nixpkgs/commit/fb4effc66a39dbe7111178214aec1b8bd132f584) | `` drift: 1.1.0 -> 1.3.0 ``                                                                         |
| [`a741364d`](https://github.com/NixOS/nixpkgs/commit/a741364d0ad13e75a2bd0cc726fafa178aee9503) | `` libretro.nestopia: 0-unstable-2026-08-30 -> 0-unstable-2026-09-06 ``                             |
| [`12c73a6e`](https://github.com/NixOS/nixpkgs/commit/12c73a6e4a60c26670b9ae8b0cc8de48dea514b9) | `` vimPlugins.copilot-lua: fix packaged language server ``                                          |
| [`57a585bb`](https://github.com/NixOS/nixpkgs/commit/57a585bb99e9d9393608b75bcfa63f1eb508fe54) | `` resterm: 1.5.0 -> 1.7.2 ``                                                                       |
| [`246b4543`](https://github.com/NixOS/nixpkgs/commit/246b4543828f1f30d8af07d638d472514dbcefbf) | `` python3Packages.transformers: 5.16.1 -> 5.17.0 ``                                                |
| [`c9aa87bd`](https://github.com/NixOS/nixpkgs/commit/c9aa87bde005650869888f51c55d104a46f5f640) | `` nixos/zsh: use absolute path to hostname binary ``                                               |
| [`7155d1ee`](https://github.com/NixOS/nixpkgs/commit/7155d1ee4ec94a72e1c74a139814eb798c93ffe3) | `` unciv: 4.21.14 -> 4.21.19 ``                                                                     |
| [`c8543fdb`](https://github.com/NixOS/nixpkgs/commit/c8543fdb767457c10d96930777e98a28e9af552e) | `` xandikos: 0.4.5 -> 0.4.6 ``                                                                      |
| [`4b25cdfe`](https://github.com/NixOS/nixpkgs/commit/4b25cdfe42801d72b73655a87be5f2d73c16f8ad) | `` whitesur-icon-theme: 2026-08-11 -> 2026-09-10 ``                                                 |
| [`50483eb3`](https://github.com/NixOS/nixpkgs/commit/50483eb35a40b4f7b197bd2c6343fabf2395025e) | `` freebsd.gencat: nixfmt ``                                                                        |
| [`927dda20`](https://github.com/NixOS/nixpkgs/commit/927dda20300d8bf1788d67af231d79c94e1a12cb) | `` flightdeck: init at 1.0.0 ``                                                                     |
| [`3e2afe52`](https://github.com/NixOS/nixpkgs/commit/3e2afe52ee796973ab485c3e3a462943b837e500) | `` python3Packages.cadwyn: 7.2.0 -> 7.3.0 ``                                                        |
| [`b2c88c5c`](https://github.com/NixOS/nixpkgs/commit/b2c88c5c57103d89b9dfb22586abfcedec275a69) | `` python3Packages.ibm-cloud-sdk-core: migrate to finalAttrs ``                                     |
| [`8576c862`](https://github.com/NixOS/nixpkgs/commit/8576c862604d8b909b259161dc4fe342e0ac3ead) | `` python3Packages.tencentcloud-sdk-python: 3.1.172 -> 3.1.173 ``                                   |
| [`bac951bd`](https://github.com/NixOS/nixpkgs/commit/bac951bd8bec51149eb89eab78c47d9ca00b03b7) | `` python3Packages.iamdata: 0.1.202609091 -> 0.1.202609101 ``                                       |
| [`c0a7c390`](https://github.com/NixOS/nixpkgs/commit/c0a7c390ddd0e453ed0e65670e9641153faae919) | `` python3Packages.boto3-stubs: 1.43.90 -> 1.43.91 ``                                               |
| [`f02f69f3`](https://github.com/NixOS/nixpkgs/commit/f02f69f37f5880e8995bff2ac231cefb785961c0) | `` saucectl: 0.213.0 -> 0.214.0 ``                                                                  |
| [`7a840d7b`](https://github.com/NixOS/nixpkgs/commit/7a840d7be8806ae74b557eef923fc1dd7c4ee281) | `` python3Packages.mypy-boto3-mediatailor: 1.43.89 -> 1.43.91 ``                                    |
| [`3a501612`](https://github.com/NixOS/nixpkgs/commit/3a5016126c92fe30b9078c09886272c1aa6d6598) | `` python3Packages.mypy-boto3-mediapackagev2: 1.43.67 -> 1.43.91 ``                                 |
| [`34dd7945`](https://github.com/NixOS/nixpkgs/commit/34dd79455bdc9fc71b96875f48957764f79947e0) | `` python3Packages.mypy-boto3-medialive: 1.43.87 -> 1.43.91 ``                                      |
| [`3dbcf4c5`](https://github.com/NixOS/nixpkgs/commit/3dbcf4c5e61df11cfd341d62a63a216b86251cb9) | `` python3Packages.mypy-boto3-lambda: 1.43.86 -> 1.43.91 ``                                         |
| [`86935d3d`](https://github.com/NixOS/nixpkgs/commit/86935d3d291041f3e4e5c0b3c3f841f884cdd329) | `` python3Packages.mypy-boto3-ec2: 1.43.90 -> 1.43.91 ``                                            |
| [`5b7aaa19`](https://github.com/NixOS/nixpkgs/commit/5b7aaa19d0971fb2d7baf3449c56db03b3b20801) | `` python3Packages.mypy-boto3-connect: 1.43.90 -> 1.43.91 ``                                        |
| [`19de6ba6`](https://github.com/NixOS/nixpkgs/commit/19de6ba60cbf893e6ad835efd6997759177a7226) | `` vimPlugins.nvim-treesitter: update grammars ``                                                   |
| [`3a3e9699`](https://github.com/NixOS/nixpkgs/commit/3a3e969930fb8a28345edbc80a39a54084e743d2) | `` vimPlugins: resolve github repository redirects ``                                               |
| [`1b6f816d`](https://github.com/NixOS/nixpkgs/commit/1b6f816df812d7f8de0282127a38181b5a86161c) | `` vimPlugins.vim-fern: 1.59.1 -> 1.59.2 ``                                                         |
| [`5981484c`](https://github.com/NixOS/nixpkgs/commit/5981484c572a695c3738757265e9e15f90bf2115) | `` vimPlugins.project-nvim: 6.1.0-1 -> 6.2.0-1 ``                                                   |
| [`32b3f220`](https://github.com/NixOS/nixpkgs/commit/32b3f2200cdf994819eef128356eb7026f88c3fc) | `` vimPlugins.onedarkpro-nvim: 2.28.0-unstable-2026-08-17 -> 2.29.0 ``                              |
| [`16c3caef`](https://github.com/NixOS/nixpkgs/commit/16c3caef1c6884edfa257c42b80d0d1ae2421d49) | `` vimPlugins.oklch-color-picker-nvim: 5.0.2 -> 5.0.5 ``                                            |
| [`c38ac784`](https://github.com/NixOS/nixpkgs/commit/c38ac784ee9db1d106b27102ef523c9fcd44f956) | `` vimPlugins.neotest-java: 0.38.3 -> 0.38.4 ``                                                     |
| [`3ef1a155`](https://github.com/NixOS/nixpkgs/commit/3ef1a1557b276c1c4c5d4fe0848beb4e32efab4e) | `` vimPlugins.live-preview-nvim: 0.9.6 -> 0.9.7 ``                                                  |
| [`a4013a0d`](https://github.com/NixOS/nixpkgs/commit/a4013a0d6136462485afbce47a21f5df77c78fdb) | `` vimPlugins.indent-blankline-nvim: 3.10.0 -> 3.10.1 ``                                            |
| [`bfcf699b`](https://github.com/NixOS/nixpkgs/commit/bfcf699b0bafaeb0751853b46fb4673e040e2b79) | `` vimPlugins.copilot-lua: 3.0.4 -> 3.1.5 ``                                                        |
| [`c68df13d`](https://github.com/NixOS/nixpkgs/commit/c68df13df8448083e4ac87b763ba28974e4beb40) | `` vimPlugins.blink-indent: 2.2.0 -> 2.3.0 ``                                                       |
| [`29773c06`](https://github.com/NixOS/nixpkgs/commit/29773c06f03a23c042bbfac043232ba83ac43382) | `` vimPlugins.astrolsp: 4.0.1 -> 4.0.3 ``                                                           |
| [`704cf009`](https://github.com/NixOS/nixpkgs/commit/704cf0093a71338cb98e75178e7a4b18eddb5aca) | `` vimPlugins.astrocore: 3.1.0 -> 3.1.1 ``                                                          |
| [`73918201`](https://github.com/NixOS/nixpkgs/commit/73918201531a8ed5b7891ce3151afdd12887add1) | `` vimPlugins.LazyVim: 16.0.0 -> 16.0.1 ``                                                          |
| [`d48e6ea3`](https://github.com/NixOS/nixpkgs/commit/d48e6ea31f6f721e3681a25277580774f27dddfe) | `` vimPlugins: update on 2026-09-10 ``                                                              |
| [`c15e9c34`](https://github.com/NixOS/nixpkgs/commit/c15e9c343a7661553e3fd50e6f6936bddd864c10) | `` stowaway: init at 1.0.1 ``                                                                       |
| [`0ab5afc2`](https://github.com/NixOS/nixpkgs/commit/0ab5afc29caed829fcda3a762f481be4d3fe1355) | `` cloudquery: 6.41.1 -> 6.42.2 ``                                                                  |
| [`f7febd59`](https://github.com/NixOS/nixpkgs/commit/f7febd59604cdb23bc4c554aad3e9237c6f9a0b6) | `` nixos/komodo-periphery: fix path issues for docker, git, and system tools ``                     |
| [`73133ce9`](https://github.com/NixOS/nixpkgs/commit/73133ce90eeec9a0fd8b7af4a53ebb8c6864fb89) | `` luaPackages.rustaceanvim: 9.2.0-2 -> 9.2.1-2 ``                                                  |
| [`93b38d04`](https://github.com/NixOS/nixpkgs/commit/93b38d04c01cf46e3e01c11865c777d1763a7c83) | `` kyverno: 1.19.0 -> 1.19.1 ``                                                                     |
| [`c021989a`](https://github.com/NixOS/nixpkgs/commit/c021989a4de1d57fde89b795e64c03821d2740e5) | `` luaPackages.luaossl: 20250929-0 -> 20260910-0 ``                                                 |
| [`fdcf477b`](https://github.com/NixOS/nixpkgs/commit/fdcf477ba9cd132cd660849bdf77a46a5fd093b5) | `` luaPackages.lua-resty-openidc: 1.9.0-1 -> 1.9.1-1 ``                                             |
| [`031050e4`](https://github.com/NixOS/nixpkgs/commit/031050e4b055b87f58bbf482148e764b9555b5ed) | `` yaziPlugins.zoom: 0-unstable-2026-09-01 → 0-unstable-2026-09-09 ``                               |
| [`157ffa69`](https://github.com/NixOS/nixpkgs/commit/157ffa6957d1367a80c71c54dfe114c135ba3741) | `` yaziPlugins.vcs-files: 0-unstable-2026-09-01 → 0-unstable-2026-09-09 ``                          |
| [`089e4a34`](https://github.com/NixOS/nixpkgs/commit/089e4a341ce6876a8de9ef6fd1e058906fd12f46) | `` yaziPlugins.restore: 0-unstable-2026-07-22 → 0-unstable-2026-09-08 ``                            |
| [`21c7b99e`](https://github.com/NixOS/nixpkgs/commit/21c7b99e56233b86faf40fa71e9033e79166a460) | `` yaziPlugins.mediainfo: 0-unstable-2026-08-31 → 0-unstable-2026-09-08 ``                          |
| [`13035f03`](https://github.com/NixOS/nixpkgs/commit/13035f03111376da3764958e996b5f0c90925e0d) | `` yaziPlugins.gvfs: 0-unstable-2026-08-29 → 0-unstable-2026-09-08 ``                               |
| [`49f4afea`](https://github.com/NixOS/nixpkgs/commit/49f4afea0d1f786e1c2ebcabb346535c66cfdabe) | `` yaziPlugins.drag: 0-unstable-2026-02-21 → 0-unstable-2026-09-08 ``                               |
| [`78b238ed`](https://github.com/NixOS/nixpkgs/commit/78b238ed0fb23c0c7e21e2d9542b371995bfbb53) | `` python3Packages.dm-control: 1.0.45 -> 1.0.46 ``                                                  |
| [`c4b89a17`](https://github.com/NixOS/nixpkgs/commit/c4b89a17f6f05026e0eb27fc7943ed3bf652e43d) | `` mujoco: 3.12.0 -> 3.13.0 ``                                                                      |
| [`c600a400`](https://github.com/NixOS/nixpkgs/commit/c600a4007d7299ac3155100adbac549c67d4b371) | `` fastp: 1.3.6 -> 1.3.7 ``                                                                         |
| [`18584675`](https://github.com/NixOS/nixpkgs/commit/18584675a296b6f7323dfadab143c21581ec22d5) | `` python3Packages.executorch: skip failing tests on python>=3.14 ``                                |
| [`5058e2a2`](https://github.com/NixOS/nixpkgs/commit/5058e2a2f4d6313b687846606c4402e34c4a6c99) | `` ctlptl: 0.9.5 -> 0.9.6 ``                                                                        |
| [`3214b1ab`](https://github.com/NixOS/nixpkgs/commit/3214b1ab54daa345f6426a0bcdf8447884707084) | `` python3Packages.pgmpy: skip failing test on aarch64-linux ``                                     |
| [`5e5af809`](https://github.com/NixOS/nixpkgs/commit/5e5af809d5d8c735814677f1019e39d015c36b41) | `` python3Packages.pgmpy: enable __structuredAttrs ``                                               |
| [`c42d04c8`](https://github.com/NixOS/nixpkgs/commit/c42d04c88f430a87dc6195f03e7506502e2b313d) | `` python3Packages.pgmpy: explicitly add setuptools to build-system ``                              |
| [`9d6fe22b`](https://github.com/NixOS/nixpkgs/commit/9d6fe22b559849c646cb0140b127dd6ac9fe5023) | `` music-assistant: skip failing test on aarch64-linux ``                                           |
| [`6c39e19c`](https://github.com/NixOS/nixpkgs/commit/6c39e19c7f56724eb465207c78e2a2d8005c7ffb) | `` cuda-oxide: init at 0.2.1 ``                                                                     |
| [`12e2ac7e`](https://github.com/NixOS/nixpkgs/commit/12e2ac7e013d9554ff1c62858de82558d441ca5a) | `` libp11: 0.4.18 -> 0.4.21 ``                                                                      |
| [`4aaf9f6f`](https://github.com/NixOS/nixpkgs/commit/4aaf9f6f4b9621d0dc0d104d8f16abc209f54f6e) | `` tgrep: 1.0.4 -> 1.0.5 ``                                                                         |
| [`342b4358`](https://github.com/NixOS/nixpkgs/commit/342b4358b47d17438dd554488c004c114b52e84d) | `` release: drop darwin.linux-builder ``                                                            |
| [`eac0d9c5`](https://github.com/NixOS/nixpkgs/commit/eac0d9c54ea65be110b1b9f617e433063efdf5b7) | `` harper: 2.8.0 -> 2.10.0 ``                                                                       |
| [`9278df68`](https://github.com/NixOS/nixpkgs/commit/9278df685988a59d68e892c208c2c8dc13342302) | `` nginxModules.vod: 1.9.1 -> 1.9.2 ``                                                              |
| [`17902fdc`](https://github.com/NixOS/nixpkgs/commit/17902fdcb7e8097b6fe472fba7f6353f5f7b586f) | `` ty: 0.0.79 -> 0.0.80 ``                                                                          |
| [`f8c829b3`](https://github.com/NixOS/nixpkgs/commit/f8c829b365abe16f3e93de257b1d6c15a43bfbf4) | `` everest: 6485 -> 6531 ``                                                                         |
| [`d3f65441`](https://github.com/NixOS/nixpkgs/commit/d3f65441a6d8e0388a39cbe45b1aa9eb34826f7b) | `` dart-sass: 1.103.0 -> 1.104.0 ``                                                                 |
| [`22f422ef`](https://github.com/NixOS/nixpkgs/commit/22f422ef3beff0362a29f29e28ae3559a000170a) | `` terraform-providers.aliyun_alicloud: 1.290.0 -> 1.292.0 ``                                       |
| [`445c4594`](https://github.com/NixOS/nixpkgs/commit/445c45946c4c38a8f5e11baa23a5b07ead801453) | `` repgrep: 0.17.0 -> 0.17.1 ``                                                                     |
| [`dc9fb72b`](https://github.com/NixOS/nixpkgs/commit/dc9fb72b09e61ac5857b2305b21d6591cab655ec) | `` tinyauth: 5.1.3 -> 5.2.0 ``                                                                      |
| [`3466897b`](https://github.com/NixOS/nixpkgs/commit/3466897b32513e0d9fa8ad6c009a24909ea89195) | `` nixos/incus/virtual-machine: add hydra build product ``                                          |
| [`2b44460a`](https://github.com/NixOS/nixpkgs/commit/2b44460a5fce4df45d29c7e889d84feaa735127e) | `` ersatztv: 26.8.1 -> 26.9.0 ``                                                                    |
| [`05c1868c`](https://github.com/NixOS/nixpkgs/commit/05c1868ce70fa87a99365de412e6980b118a143f) | `` linecast: 2.2.0 -> 2.3.3 ``                                                                      |
| [`d67b25b7`](https://github.com/NixOS/nixpkgs/commit/d67b25b798661e050c3eae0b2a9f70e551d240c6) | `` python3Packages.specialized-turbo: 0.8.2 -> 0.8.3 ``                                             |
| [`407090a0`](https://github.com/NixOS/nixpkgs/commit/407090a0d27c2efe99069d87ca25a90b8ddda02c) | `` tuple: 0-unstable-2026-08-27 -> 0-unstable-2026-09-07 ``                                         |
| [`81afd685`](https://github.com/NixOS/nixpkgs/commit/81afd6854020f4132d6dc5a6378cb1c4b6f514b9) | `` freerouting: 2.2.4 -> 2.4.1 ``                                                                   |
| [`4076baa9`](https://github.com/NixOS/nixpkgs/commit/4076baa97ba1f0812fa6a83bd64eaf722aa8474e) | `` czkawka: 12.0.1 -> 12.0.2 ``                                                                     |
| [`8ac617ba`](https://github.com/NixOS/nixpkgs/commit/8ac617badf946ca2cfe1451fff9463e9dc369856) | `` x42-plugins: 20260829 -> 20260908 ``                                                             |
| [`28da5849`](https://github.com/NixOS/nixpkgs/commit/28da584985ef9549fceb7c7a9e66eaeeeceffd20) | `` x42-avldrums: 0.7.5 -> 0.7.6 ``                                                                  |
| [`f17556f4`](https://github.com/NixOS/nixpkgs/commit/f17556f4272c5c8261abc4da94f3e5ae86ce750e) | `` libphonenumber: 9.0.38 -> 9.0.39 ``                                                              |
| [`a609c16a`](https://github.com/NixOS/nixpkgs/commit/a609c16a714196fe537064220804f5a94ccce4eb) | `` faust-physicalmodeling: 2.85.9 -> 2.88.0 ``                                                      |
| [`9527c2a8`](https://github.com/NixOS/nixpkgs/commit/9527c2a8052ef9230d3afc0e22e5d871c7a4d6e8) | `` uftpd: 2.16 -> 2.17 ``                                                                           |
| [`47a782a1`](https://github.com/NixOS/nixpkgs/commit/47a782a18dab064adec24852056e014a8a3f689e) | `` gnmic: 0.47.0 -> 0.48.0 ``                                                                       |
| [`c6da27eb`](https://github.com/NixOS/nixpkgs/commit/c6da27eb8a120fe59dbaed2f9c94edbaa8b60a1f) | `` sq: 0.54.1 -> 0.55.0 ``                                                                          |
| [`b6238775`](https://github.com/NixOS/nixpkgs/commit/b6238775c3c30562acfcf74962673ce89190b577) | `` spicetify-cli: 2.44.0 -> 2.45.0 ``                                                               |
| [`174dc48a`](https://github.com/NixOS/nixpkgs/commit/174dc48a4bbdd067e3a58dfbbf7f0e62dff4c30c) | `` gopodder: 1.2.4 -> 1.2.5 ``                                                                      |
| [`bdbd819c`](https://github.com/NixOS/nixpkgs/commit/bdbd819c4ae8ac3434f547f2dd10fd703775bc2b) | `` mcp-searxng: 2.1.0 -> 2.2.0 ``                                                                   |
| [`eb0b6a39`](https://github.com/NixOS/nixpkgs/commit/eb0b6a39e23a814d98c78f4ff2b25ac3b792aa67) | `` sesh: 2.28.0 -> 2.29.0 ``                                                                        |
| [`c532ea7e`](https://github.com/NixOS/nixpkgs/commit/c532ea7ea4d10914de76bfc66b36a90207ce21df) | `` walker: remove adamcstephens as maintainer ``                                                    |
| [`916c5a6a`](https://github.com/NixOS/nixpkgs/commit/916c5a6afab7622bec6a8c5bed6031d73c9725b8) | `` pythonPackages.sabctools: remove adamcstephens as maintainer ``                                  |
| [`98154bcd`](https://github.com/NixOS/nixpkgs/commit/98154bcde31381b4a815da86b2f9d577e96dab1a) | `` garage: remove adamcstephens as maintainer ``                                                    |
| [`c0eee9ac`](https://github.com/NixOS/nixpkgs/commit/c0eee9aca8456dec03e2e7579673b43b7c76c67f) | `` sabnzbd: remove adamcstephens as maintainer ``                                                   |
| [`b7face9e`](https://github.com/NixOS/nixpkgs/commit/b7face9e0d8f2abb3ce3cb8bba0aaf3db257d0ef) | `` elephant: remove adamcstephens as maintainer ``                                                  |
| [`1a3dce4b`](https://github.com/NixOS/nixpkgs/commit/1a3dce4b9e200e83a3c014b60e04e4d8277d1b63) | `` libretro.gearcoleco: init at 1.6.6 ``                                                            |
| [`8aec63ba`](https://github.com/NixOS/nixpkgs/commit/8aec63ba82fe4a9c7660bba90e99a02639f7dedb) | `` libretro.freechaf: init at 0-unstable-2026-04-20 ``                                              |
| [`ea262317`](https://github.com/NixOS/nixpkgs/commit/ea262317f682153e12c15318b5e404ff253b85e2) | `` libretro.jaxe: init at 0-unstable-2026-04-02 ``                                                  |
| [`46d999e9`](https://github.com/NixOS/nixpkgs/commit/46d999e950050d21d54ad25baa256830f1710ca1) | `` libretro.pd777: init at 0-unstable-2026-06-19 ``                                                 |
| [`6007889f`](https://github.com/NixOS/nixpkgs/commit/6007889f40bdf375f66056642db1631c330018be) | `` maintainers: add ZainKergaye ``                                                                  |
| [`5825be34`](https://github.com/NixOS/nixpkgs/commit/5825be3485ad3ec65c4dfb8f53a522e7710e71a8) | `` weylus: unstable-2025-10-08 -> unstable-2026-2-16 ``                                             |
| [`77258780`](https://github.com/NixOS/nixpkgs/commit/77258780e225eda0f41f3f792c9747928b902c8f) | `` wootility: 5.4.1 -> 5.4.2 ``                                                                     |
| [`abb04c76`](https://github.com/NixOS/nixpkgs/commit/abb04c76cc958e0f2a6d858e38e3d7a4212afc0d) | `` shattered-pixel-dungeon: 3.3.8 -> 4.0.0 ``                                                       |
| [`dfe028fa`](https://github.com/NixOS/nixpkgs/commit/dfe028faf2efd112b7748db508df217c28657549) | `` steam-art-manager: 3.17.0 -> 3.18.0 ``                                                           |
| [`75dcb3e8`](https://github.com/NixOS/nixpkgs/commit/75dcb3e83132498557deb9748017439220e1addd) | `` soundalike: 0.1.2 -> 0.1.3 ``                                                                    |
| [`7ab180b8`](https://github.com/NixOS/nixpkgs/commit/7ab180b87d710502ed5b0eee01144d207a816be6) | `` codex: 0.153.4 -> 0.154.0 ``                                                                     |
| [`0fc17cf5`](https://github.com/NixOS/nixpkgs/commit/0fc17cf5032cfdffebdfce5b6509eaa6823d7d60) | `` python3Packages.crownstone-uart: add meta.changelog ``                                           |
| [`28dea62c`](https://github.com/NixOS/nixpkgs/commit/28dea62c35b8b3ec6092ca4efafc422b0e01d040) | `` libretro.theodore: init at 0-unstable-2026-04-03 ``                                              |
| [`7ab13cd6`](https://github.com/NixOS/nixpkgs/commit/7ab13cd61f77b85e2d643bcd76ac0c1695b596e6) | `` python3Packages.airos: 0.6.11 -> 0.6.12 ``                                                       |
| [`ace2ce94`](https://github.com/NixOS/nixpkgs/commit/ace2ce94f8cd2f550e1cea72b7ec6d7ad64b049f) | `` python3Packages.quantiphy: 2.22.1 -> 2.23 ``                                                     |
| [`f36469d0`](https://github.com/NixOS/nixpkgs/commit/f36469d0b0e4633696a109f3867195c0464d1353) | `` python3Packages.moyopy: 0.17.0 -> 0.18.0 ``                                                      |
| [`21fc83ea`](https://github.com/NixOS/nixpkgs/commit/21fc83ea84bf44eedaed2b058df5d7988681d3b0) | `` vscode-extensions.vytautassurvila.csharp-ls: 0.0.34 -> 0.0.35 ``                                 |
| [`fed2cd75`](https://github.com/NixOS/nixpkgs/commit/fed2cd75b477548e46ded135aa2c2557ffc93fbb) | `` python3Packages.solaredge-web: 0.4.0 -> 0.5.0 ``                                                 |
| [`edb4be03`](https://github.com/NixOS/nixpkgs/commit/edb4be03b1cf64d99d6499f6e36f7bf7b82d7199) | `` python3Packages.actron-neo-api: 0.5.14 -> 0.5.16 ``                                              |
| [`1adc4505`](https://github.com/NixOS/nixpkgs/commit/1adc4505e84ee2f8b70ddfcfce4247a9e3310783) | `` whisper-cpp: use ffmpeg-headless ``                                                              |
| [`fba7dfd8`](https://github.com/NixOS/nixpkgs/commit/fba7dfd86ad057ec3deb6ce8ead0990bdd7a9f79) | `` freebsd: correctly don't assume packages will build for platforms other than freebsd ``          |
| [`d5afa32f`](https://github.com/NixOS/nixpkgs/commit/d5afa32f03c6a2225d90383f3ca10e0df235e656) | `` python3Packages.torchcodec: use ffmpeg-headless ``                                               |
| [`fae59201`](https://github.com/NixOS/nixpkgs/commit/fae59201a41bf913ff225e4927b5ca1db9be6203) | `` babashka-unwrapped: 1.13.219 -> 1.13.220 ``                                                      |
| [`7ab9b835`](https://github.com/NixOS/nixpkgs/commit/7ab9b835bc685ac071de926c3c4d0bd5a375a6ef) | `` linuxKernel.kernels.linux_zen: 7.2.3 -> 7.2.4 ``                                                 |
| [`55de9b98`](https://github.com/NixOS/nixpkgs/commit/55de9b9800045cf8754e6021fa00507acb191fa2) | `` dutctl: 1.0.0-alpha.2-unstable-2026-08-25 -> 1.0.0-alpha.3-unstable-2026-09-09 ``                |
| [`aa2d3063`](https://github.com/NixOS/nixpkgs/commit/aa2d306386295ee19a26f9d8505746a1cc81c191) | `` audiowaveform: fix changelog URL ``                                                              |
| [`056f7c74`](https://github.com/NixOS/nixpkgs/commit/056f7c7411a984bf7caa9d62565ab2a81b00b46a) | `` python3Packages.crownstone-core: add meta.changelog ``                                           |
| [`ead9e32f`](https://github.com/NixOS/nixpkgs/commit/ead9e32f611268e4d4eef4970429f88090f53d5c) | `` python3Packages.configclass: add meta.changelog ``                                               |
| [`036961dd`](https://github.com/NixOS/nixpkgs/commit/036961ddbff8ced6b00f3f8e82ba46d6ee8860ef) | `` devin-desktop: 3.8.20 -> 3.9.19 ``                                                               |
| [`eb4e90ee`](https://github.com/NixOS/nixpkgs/commit/eb4e90eed92c045fbf2894e2944f61d3a74e9a46) | `` chromium,chromedriver: 152.0.7977.82 -> 153.0.8010.36 ``                                         |
| [`290c28d4`](https://github.com/NixOS/nixpkgs/commit/290c28d4a1316ee1aa646000dc6b5d7f5d94b427) | `` android-translation-layer: support aarch64 cross compilation ``                                  |
| [`2f088fe2`](https://github.com/NixOS/nixpkgs/commit/2f088fe2791065b1d2eec359c19844dea013ba9b) | `` art-standalone: fix aarch64 cross-compilation ``                                                 |
| [`45f5a8d7`](https://github.com/NixOS/nixpkgs/commit/45f5a8d70b6663a9cd7b142d133bd1b00b8a4d67) | `` fladder: 0.11.0 -> 0.11.1 ``                                                                     |
| [`d214ef56`](https://github.com/NixOS/nixpkgs/commit/d214ef56b7d99b2e0a1cd5195f8d6e0ca68ac1c5) | `` atuin: 18.19.0 -> 18.21.0 ``                                                                     |
| [`a8128c61`](https://github.com/NixOS/nixpkgs/commit/a8128c61814ff594c9d3f4cb44521153e357b8a5) | `` picotool: 2.3.0 -> 2.3.1 ``                                                                      |
| [`90068758`](https://github.com/NixOS/nixpkgs/commit/900687585d660d3b40bd2ce6bffeb8eddcf81c33) | `` vi-mongo: 0.3.0 -> 0.3.1 ``                                                                      |
| [`b6c0ae5f`](https://github.com/NixOS/nixpkgs/commit/b6c0ae5fd1ca9bf743267690ce8f9db657487124) | `` python3Packages.llama-index-vector-stores-milvus: 1.1.0 -> 1.2.0 ``                              |
| [`98dc18f4`](https://github.com/NixOS/nixpkgs/commit/98dc18f4a58faed7b09f0f39d896cdf39e8d014a) | `` databricks-cli: 1.14.0 -> 1.16.0 ``                                                              |

*... and 1966 more commits (truncated)*